### PR TITLE
Update .gitignore to not ignore beetbox-* roles.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ ansible/project.config.yml
 ansible/vagrant.config.yml
 ansible/local.config.yml
 ansible/roles/
+!ansible/roles/beetbox-*
 local.config.yml
 
 # Prevent miscellaneous/system files.


### PR DESCRIPTION
Currently .gitignore ignores all **ansible/roles**, including the two **beetbox-**\* roles, making it difficult for people to contribute to the roles.

Simple issue, simple fix.
