### PR TITLE
Add Avahi

### DIFF
--- a/ansible/beetbox.config.yml
+++ b/ansible/beetbox.config.yml
@@ -54,6 +54,7 @@ galaxy_roles:
   - { name: geerlingguy.solr }
   - { name: geerlingguy.varnish }
   - { name: heskethm.wp-cli }
+  - { name: pwelch.avahi }
   - { name: thomtoogood.beetbox-backdrop }
   - { name: thomtoogood.beetbox-cakephp }
   - { name: thomtoogood.beetbox-concrete5 }
@@ -123,6 +124,8 @@ firewall_allowed_tcp_ports:
   - "8080"
   - "8443"
   - "8983"
+firewall_allowed_udp_ports:
+  - "5353"
 firewall_log_dropped_packets: false
 
 # git config.

--- a/ansible/roles/beetbox-common/meta/main.yml
+++ b/ansible/roles/beetbox-common/meta/main.yml
@@ -9,6 +9,7 @@ dependencies:
   - { role: geerlingguy.php-pecl }
   - { role: geerlingguy.php-mysql }
   - { role: geerlingguy.composer }
+  - { role: pwelch.avahi }
 
   # Conditionally-installed roles.
   - { role: geerlingguy.memcached, when: '"memcached" in installed_extras' }


### PR DESCRIPTION
> Avahi is a free zero-configuration networking (zeroconf) implementation, including a system for multicast DNS/DNS-SD service discovery.

What that means is that with Avahi you can use DHCP without the need of any plugins on a Mac or *nix based host. Windows will still need to fallback to the plugins, but that is up to the Vagrantfile, which will be dealt with in a subsequent PR.
