### PR TITLE
#22: Add known hosts task.

### DIFF
--- a/ansible/beetbox.config.yml
+++ b/ansible/beetbox.config.yml
@@ -67,6 +67,9 @@ galaxy_roles:
 # Symlinks.
 symlinks: no
 
+# Known hosts.
+known_hosts: no
+
 # Apache config.
 apache_daemon: apache2
 apache_vhosts:

--- a/ansible/playbook-provision.yml
+++ b/ansible/playbook-provision.yml
@@ -13,6 +13,10 @@
   pre_tasks:
     - include: tasks/init.yml
 
+    # Create known_hosts.
+    - include: tasks/known-hosts.yml
+      when: known_hosts
+
   roles:
     - { role: beetbox-common }
     - { role: beetbox-drupal, when: beet_project == 'drupal' }

--- a/ansible/tasks/known-hosts.yml
+++ b/ansible/tasks/known-hosts.yml
@@ -1,0 +1,7 @@
+---
+- name: Ensure known hosts exist
+  known_hosts:
+    path: "{{ known_hosts_path }}"
+    name: "{{ item }}"
+    key: "{{ lookup('pipe', 'ssh-keyscan -t rsa ' + item) }}"
+  with_items: "{{ known_hosts }}"


### PR DESCRIPTION
Add's the ability to add known_hosts via Ansible prior to the build tasks.

Format is:

```
known_hosts:
  - github.com
  - example.com
```

This is based on http://hakunin.com/six-ansible-practices#path-to-success-1 but with the Ansible extra module `known_hosts`.
