### PR TITLE
#37: Change to Ansible 1.9.4

### DIFF
--- a/tests/dependencies.sh
+++ b/tests/dependencies.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-sudo pip install ansible
+sudo pip install ansible==1.9.4
 sudo apt-get update
 sudo apt-get purge apache2 php5-cli mysql-common mysql-server
 sudo rm -rf /etc/apache2/mods-enabled/*


### PR DESCRIPTION
Tests are currently failing due to the release of Ansible 2.0.0. The resolve this issue temporarily I have enforced the usage of Ansible 1.9.4 in the test dependencies.

The box is still currently using 1.9.4, and a test build has shown that 1.9.4 is still the current version retrieved by `apt-get`, but I will make a similar Pull Request for the packer template to ensure that if that does change we are still using 1.9.4 for the time being.
