### PR TITLE
Update Drush to 8.0.2

### DIFF
--- a/ansible/beetbox.config.yml
+++ b/ansible/beetbox.config.yml
@@ -195,7 +195,8 @@ composer_home_group: vagrant
 #   - { name: phpunit/phpunit, release: '@stable' }
 
 # Drush config.
-drush_version: "8.0.0-rc4"
+drush_version: "8.0.2"
+drush_keep_updated: yes
 drush_composer_cli_options: "--prefer-dist --no-interaction"
 
 # MySQL config.


### PR DESCRIPTION
Current Drush is an outdated release candidate and should be updated to the latest stable.

Considered just putting it to 8.0.x, but decided to stick with a stable release for the moment. Anyone is able to make this change on their own specific project or fork.
