### PR TITLE
Add support for Drush make-ing of distributions.

### DIFF
--- a/ansible/roles/beetbox-drupal/defaults/main.yml
+++ b/ansible/roles/beetbox-drupal/defaults/main.yml
@@ -5,6 +5,8 @@ drupal_account_name: admin
 drupal_account_pass: admin
 drupal_install_site: no
 drupal_build_makefile: no
+drupal_distro: no
+drupal_distro_makefile: /vagrant/drupal-org.make.yml
 drupal_makefile_path: /vagrant/drupal.make.yml
 drupal_build_composer: no
 drupal_composer_version: "8.x-dev"

--- a/ansible/roles/beetbox-drupal/tasks/build-makefile.yml
+++ b/ansible/roles/beetbox-drupal/tasks/build-makefile.yml
@@ -1,6 +1,24 @@
 ---
 - name: Generate Drupal site with drush makefile.
   command: >
-    {{ drush_path }} make -y {{ drupal_makefile_path }} --no-gitinfofile
+    {{ drush_path }} make -y {{ drupal_makefile_path }} --no-gitinfofile {% if drupal_distro %}--no-recursion{% endif %}
     chdir={{ beet_root }}
   when: not drupal_site.stat.exists
+
+- name: Remove built distribution profile directory.
+  command: >
+    rm -rf {{ beet_root }}/profiles/{{ drupal_distro }}
+  when: not drupal_site.stat.exists and drupal_distro
+
+- name: Symlink distribution profile directory to root directory.
+  file:
+    src: "../.."
+    dest: "{{ beet_root }}/profiles/{{ drupal_distro }}"
+    state: link
+  when: not drupal_site.stat.exists and drupal_distro
+
+- name: Build distribution profile makefile.
+  command: >
+    {{ drush_path }} make -y {{ drupal_distro_makefile }} --no-gitinfofile --no-core --contrib-destination=./
+    chdir={{ beet_root }}/profiles/{{ drupal_distro }}
+  when: not drupal_site.stat.exists and drupal_distro

--- a/ansible/roles/beetbox-drupal/tasks/build-makefile.yml
+++ b/ansible/roles/beetbox-drupal/tasks/build-makefile.yml
@@ -6,8 +6,9 @@
   when: not drupal_site.stat.exists
 
 - name: Remove built distribution profile directory.
-  command: >
-    rm -rf {{ beet_root }}/profiles/{{ drupal_distro }}
+  file:
+    path: "{{ beet_root }}/profiles/{{ drupal_distro }}"
+    state: absent
   when: not drupal_site.stat.exists and drupal_distro
 
 - name: Symlink distribution profile directory to root directory.


### PR DESCRIPTION
This adds support for Drush make-ing of distributions. Specifically, it does the following:

If `drupal_distro` is set (to the name of a profile):
- Build the `drupal_makefile_path` with `--no-recursion` as we want to use the local distro makefile as the source, not the version reference in the stub makefile
- Delete the built profile directory
- Symlink the profile directory to the project root as it is the profile
- Build the `drupal_distro_makefile` with `--no-core --contrib-destination=./` inside the profile directory

With this, whenever you are working within `[DOCROOT]/profiles/[PROFILE]` you are actually working inside the project root, which is likely the git root.
