### PR TITLE
Update Drush update to be linked to Beet update.

### DIFF
--- a/ansible/beetbox.config.yml
+++ b/ansible/beetbox.config.yml
@@ -196,7 +196,7 @@ composer_home_group: vagrant
 
 # Drush config.
 drush_version: "8.0.2"
-drush_keep_updated: yes
+drush_keep_updated: "{{ beet_keep_updated }}"
 drush_composer_cli_options: "--prefer-dist --no-interaction"
 
 # MySQL config.


### PR DESCRIPTION
Currently, due to a change I made, Drush will try to stay up to date with the specified version. This means it requires an internet connection during provision.

The reason it was done was so that users that had `beet_keep_updated` would actually get the updated Drush version.

As such, this change sets `drush_keep_updated` to use the value of `beet_keep_updated` so that it still has the same effect when you want updates, but doesn't force users provisioning to have an internet connection.
