### PR TITLE
#33: Change the default IP in the Vagrantfile.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,7 +16,7 @@ end
 
 # Default vagrant config.
 vconfig = {
-  'vagrant_ip' => '192.168.88.88',
+  'vagrant_ip' => '0.0.0.0',
   'vagrant_memory' => 1024,
   'vagrant_cpus' => 2
 }


### PR DESCRIPTION
As per #33, this changes the default IP in the Vagrantfile (but no the example .beetbox/config.yml) to use 0.0.0.0/DHCP.
