### PR TITLE
Only check for updates when overriding default drush version.

### DIFF
--- a/ansible/beetbox.config.yml
+++ b/ansible/beetbox.config.yml
@@ -196,7 +196,7 @@ composer_home_group: vagrant
 
 # Drush config.
 drush_version: "8.0.2"
-drush_keep_updated: "{{ beet_keep_updated }}"
+drush_keep_updated: "{{ (drush_version != '8.0.2') }}"
 drush_composer_cli_options: "--prefer-dist --no-interaction"
 
 # MySQL config.


### PR DESCRIPTION
This will ensure drush is always updated when the version is not the same as the default.
