### PR TITLE
Separate roles playbook from update.

### DIFF
--- a/ansible/build.sh
+++ b/ansible/build.sh
@@ -19,5 +19,8 @@ export PYTHONUNBUFFERED=1
 # Check for updates.
 ansible-playbook $DEBUG "$currentDir/playbook-update.yml" -i 'localhost,'
 
+# Install ansible galaxy roles.
+ansible-playbook $DEBUG "$currentDir/playbook-roles.yml" -i 'localhost,'
+
 # Provision VM.
 ansible-playbook $DEBUG "$currentDir/playbook-provision.yml" -i 'localhost,'

--- a/ansible/playbook-roles.yml
+++ b/ansible/playbook-roles.yml
@@ -1,0 +1,25 @@
+---
+- hosts: localhost
+  connection: local
+  user: root
+  become: yes
+
+  vars_files:
+    - beetbox.config.yml
+    - project.config.yml
+    - vagrant.config.yml
+    - local.config.yml
+
+  tasks:
+
+    - name: Install Galaxy roles
+      command: >
+        ansible-galaxy install {{ item.name }} -p {{ beet_role_dir }}
+        creates={{ beet_role_dir }}/{{ item.name }}/meta/main.yml
+      with_items: galaxy_roles
+
+    - name: Update Galaxy roles
+      command: >
+        ansible-galaxy install {{ item.name }} -p {{ beet_role_dir }} --force --ignore-errors
+      when: item.force_update is defined
+      with_items: galaxy_roles

--- a/ansible/playbook-update.yml
+++ b/ansible/playbook-update.yml
@@ -35,15 +35,3 @@
         recurse: yes
         state: directory
       when: (not beet_debug)
-
-    - name: Install Galaxy roles
-      command: >
-        ansible-galaxy install {{ item.name }} -p {{ beet_role_dir }}
-        creates={{ beet_role_dir }}/{{ item.name }}/meta/main.yml
-      with_items: galaxy_roles
-
-    - name: Update Galaxy roles
-      command: >
-        ansible-galaxy install {{ item.name }} -p {{ beet_role_dir }} --force --ignore-errors
-      when: item.force_update is defined
-      with_items: galaxy_roles


### PR DESCRIPTION
This is a fix for #57 

It will update the internal repository before installing roles. 

A new build will need to be created once this is merged.
