### PR TITLE
#59: Fix recursive symbolic link for distros.

### DIFF
--- a/ansible/roles/beetbox-drupal/tasks/build-makefile.yml
+++ b/ansible/roles/beetbox-drupal/tasks/build-makefile.yml
@@ -5,18 +5,23 @@
     chdir={{ beet_root }}
   when: not drupal_site.stat.exists
 
-- name: Remove built distribution profile directory.
+- name: Remove built distribution files/directories.
   file:
-    path: "{{ beet_root }}/profiles/{{ drupal_distro }}"
+    path: "{{ beet_root }}/profiles/{{ drupal_distro }}/{{ item }}"
     state: absent
   when: not drupal_site.stat.exists and drupal_distro
+  with_items: "{{ lookup('pipe', 'ls -A ' + beet_root + '/profiles/' + drupal_distro).split() }}"
 
-- name: Symlink distribution profile directory to root directory.
+# @TODO - This makes an assumption of the root Vagrant share which is not yet
+#         configurable. Make configurable and use variable.
+- name: Symlink distribution files/directories.
   file:
-    src: "../.."
-    dest: "{{ beet_root }}/profiles/{{ drupal_distro }}"
+    src: "../../../{{ item }}"
+    dest: "{{ beet_root }}/profiles/{{ drupal_distro }}/{{ item }}"
     state: link
-  when: not drupal_site.stat.exists and drupal_distro
+    force: yes
+  with_items: "{{ lookup('pipe', 'ls -A /www').split() }}"
+  when: not drupal_site.stat.exists and drupal_distro and item != 'docroot'
 
 - name: Build distribution profile makefile.
   command: >

--- a/ansible/roles/beetbox-drupal/tasks/build-makefile.yml
+++ b/ansible/roles/beetbox-drupal/tasks/build-makefile.yml
@@ -9,8 +9,8 @@
   file:
     path: "{{ beet_root }}/profiles/{{ drupal_distro }}/{{ item }}"
     state: absent
+  with_items: "{% if drupal_distro %}{{ lookup('pipe', 'ls -A ' + beet_root + '/profiles/' + drupal_distro).split() }}{% endif %}"
   when: not drupal_site.stat.exists and drupal_distro
-  with_items: "{{ lookup('pipe', 'ls -A ' + beet_root + '/profiles/' + drupal_distro).split() }}"
 
 # @TODO - This makes an assumption of the root Vagrant share which is not yet
 #         configurable. Make configurable and use variable.


### PR DESCRIPTION
As per #59, this fixes the recursive symbolic link for distributions by symbolically linking individual files and folders excluding the 'docroot' folder.
