### PR TITLE
#45: Temporarily disabled XHProf.

### DIFF
--- a/ansible/beetbox.config.yml
+++ b/ansible/beetbox.config.yml
@@ -101,7 +101,7 @@ installed_extras:
   - mailhog
   - memcached
   - xdebug
-  - xhprof
+  # - xhprof
   - selenium
   - drupal-console
   # - varnish


### PR DESCRIPTION
As per #45, until https://github.com/geerlingguy/ansible-role-php-xhprof/pull/2 is ready and pulled, we should disabled XHProf to provide a fully offline provisionable box.
