### PR TITLE
Updated default directories.

### DIFF
--- a/.beetbox/config.yml
+++ b/.beetbox/config.yml
@@ -7,13 +7,13 @@ vagrant_cpus: 2
 # Beetbox settings.
 beet_project: drupal
 beet_domain: "beetbox.local"
-beet_root: "/www/projects/{{ beet_project }}"
-beet_web: "{{ beet_root }}"
+beet_root: "/var/beetbox"
+beet_web: "{{ beet_root }}/projects/{{ beet_project }}"
 beet_site_name: "Beetbox"
 
 # Drupal settings.
 drupal_build_makefile: yes
-drupal_makefile_path: /www/drupal8.make.yml
+drupal_makefile_path: "{{ beet_root }}/drupal8.make.yml"
 drupal_install_site: yes
 drupal_account_name: admin
 drupal_account_pass: admin

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,6 +16,9 @@ end
 
 # Default vagrant config.
 vconfig = {
+  'beet_home' => '/beetbox',
+  'beet_root' => '/var/beetbox',
+  'beet_web' => '/var/beetbox/docroot',
   'vagrant_ip' => '0.0.0.0',
   'vagrant_memory' => 1024,
   'vagrant_cpus' => 2
@@ -79,12 +82,12 @@ Vagrant.configure("2") do |config|
       end
 
       # Synced folders.
-      node.vm.synced_folder ".", "/www",
+      node.vm.synced_folder ".", vconfig['beet_root'],
         type: "nfs",
         id: "drupal"
 
       if vconfig['beet_debug']
-        node.vm.synced_folder "./ansible", "/beetbox/ansible",
+        node.vm.synced_folder "./ansible", "#{vconfig['beet_home']}/ansible",
           type: "nfs",
           id: "ansible"
         debug_mode = "BEETBOX_DEBUG=true"

--- a/ansible/beetbox.config.yml
+++ b/ansible/beetbox.config.yml
@@ -15,8 +15,8 @@ beet_project: drupal
 beet_keep_updated: no
 beet_debug: no
 beet_domain: "beetbox.local"
-beet_root: "/www/{{ beet_project }}"
-beet_web: "{{ beet_root }}"
+beet_root: "/var/beetbox"
+beet_web: "{{ beet_root }}/docroot"
 beet_ssh_home: "{{ beet_root }}"
 beet_site_name: "Beetbox"
 beet_mysql_user: beetbox


### PR DESCRIPTION
Updates the default directories in:
- `Vagrantfile`
- `ansible/beetbox.config.yml`
- `.beetbox/config.yml`

Fixes issue with #48, so that if no `beet_web` is defined in the `.beetbox/config.yml` it will still be able to make a Drush alias using the default of `/var/beetbox/docroot`.

Also somewhat addresses #14, by providing defaults in the Vagrantfile so that the `/www` share (which is now `/var/beetbox`) can be configured without modifying the Vagrantfile.
