### PR TITLE
Add beet_base to config.

### DIFF
--- a/.beetbox/config.yml
+++ b/.beetbox/config.yml
@@ -7,6 +7,7 @@ vagrant_cpus: 2
 # Beetbox settings.
 beet_project: drupal
 beet_domain: "beetbox.local"
+beet_base: "/var/beetbox"
 beet_root: "{{ beet_base }}/projects/{{ beet_project }}"
 beet_site_name: "Beetbox"
 


### PR DESCRIPTION
Temporary workaround until next build contains the `beet_base` var.
