### PR TITLE
Skip apt cache update during offline provisioning.

### DIFF
--- a/ansible/tasks/init.yml
+++ b/ansible/tasks/init.yml
@@ -1,6 +1,7 @@
 ---
 - name: Update apt cache if needed.
   apt: update_cache=yes cache_valid_time=86400
+  failed_when: false
 
 - name: Get software for Python-based control.
   apt: "name={{ item }} state=installed"


### PR DESCRIPTION
This allows the apt cache update to fail when provisioning offline.
