### PR TITLE
Added beet_webserver var.

### DIFF
--- a/ansible/beetbox.config.yml
+++ b/ansible/beetbox.config.yml
@@ -20,6 +20,7 @@ beet_root: "{{ beet_base }}"
 beet_web: "{{ beet_root }}"
 beet_ssh_home: "{{ beet_root }}"
 beet_site_name: "Beetbox"
+beet_webserver: apache
 beet_mysql_user: beetbox
 beet_mysql_password: beetbox
 beet_mysql_database: "beetbox_{{ beet_project }}"
@@ -76,7 +77,7 @@ known_hosts: no
 # Apache config.
 apache_daemon: apache2
 apache_remove_default_vhost: true
-apache_listen_port: 80
+apache_listen_port: "{{ (beet_webserver == 'apache') | ternary('80','82') }}"
 apache_vhosts:
   - servername: "{{ beet_domain }}"
     documentroot: "{{ beet_web }}"


### PR DESCRIPTION
PR for #56.

This currently only modifies the default apache port to 82 when not 'apache', however we can reuse this variable in other situations.
