### PR TITLE
Add default nginx_hosts.

### DIFF
--- a/ansible/beetbox.config.yml
+++ b/ansible/beetbox.config.yml
@@ -155,6 +155,11 @@ ruby_install_gems: []
 
 # Nginx config.
 nginx_php_fpm: /var/run/php5-fpm.sock
+nginx_hosts:
+  - listen: "{{ (beet_webserver == 'nginx') | ternary('80','82') }}"
+    server_name: "{{ beet_domain }}"
+    root: "{{ beet_web }}"
+    is_php: true
 
 # PHP config.
 php_version: "5.6"


### PR DESCRIPTION
A recent role update requires us to define at least 1 nginx host, this is a bug as there's a specific task which should allow no vhosts to be defined -- https://github.com/geerlingguy/ansible-role-nginx/blob/master/tasks/vhosts.yml#L19
