### PR TITLE
#74: Supply a default Vagrantfile with the box.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,10 +5,10 @@ require 'yaml'
 
 Vagrant.require_version '>= 1.8.0'
 
-dir = File.dirname(File.expand_path(__FILE__))
+cwd = File.dirname(File.expand_path(__FILE__))
 config_dir = '.beetbox/'
-vagrant_config = "#{dir}/#{config_dir}config.yml"
-local_config = "#{dir}/#{config_dir}local.config.yml"
+vagrant_config = "#{cwd}/#{config_dir}config.yml"
+local_config = "#{cwd}/#{config_dir}local.config.yml"
 
 # Default vagrant config.
 vconfig = {
@@ -17,7 +17,7 @@ vconfig = {
   'vagrant_cpus' => 2,
   'beet_home' => '/beetbox',
   'beet_base' => '/var/beetbox',
-  'beet_domain' => 'beetbox.local'
+  'beet_domain' => cwd.split('/').last.gsub(/[\._]/, '-') + ".local"
 }
 
 if !File.exist?(vagrant_config)

--- a/packer/includes/Vagrantfile
+++ b/packer/includes/Vagrantfile
@@ -25,139 +25,145 @@ else
     end
   end
 end
-hostname = cwd.split('/').last.gsub(/[\._]/, '-') + ".local"
 
-config_dir = '.beetbox/'
-vagrant_config = "#{cwd}/#{config_dir}config.yml"
-local_config = "#{cwd}/#{config_dir}local.config.yml"
+# Ensure project Vagrantfile hasn't been customized.
+# @TODO - Add secondary check that parses the Vagrantfile if the MD5 is changed.
+md5 = Digest::MD5.file("#{dir}/VagrantFile").hexdigest
+if md5 == "abef0f6a03cc23bb3da842cd1d12aa50"
+  hostname = cwd.split('/').last.gsub(/[\._]/, '-') + ".local"
 
-# Default vagrant config.
-vconfig = {
-  'vagrant_ip' => '0.0.0.0',
-  'vagrant_memory' => 1024,
-  'vagrant_cpus' => 2,
-  'beet_home' => '/beetbox',
-  'beet_base' => '/var/beetbox',
-  'beet_domain' => hostname
-}
+  config_dir = '.beetbox/'
+  vagrant_config = "#{cwd}/#{config_dir}config.yml"
+  local_config = "#{cwd}/#{config_dir}local.config.yml"
 
-if !File.exist?(vagrant_config)
-  # Create default config file.
-  require 'fileutils'
-  FileUtils::mkdir_p config_dir
-  File.open(vagrant_config, "w+") {|f| f.write("---\nbeet_domain: #{vconfig['beet_domain']}\n") }
-end
+  # Default vagrant config.
+  vconfig = {
+    'vagrant_ip' => '0.0.0.0',
+    'vagrant_memory' => 1024,
+    'vagrant_cpus' => 2,
+    'beet_home' => '/beetbox',
+    'beet_base' => '/var/beetbox',
+    'beet_domain' => hostname
+  }
 
-vconfig = vconfig.merge YAML::load_file(vagrant_config)
-
-# Merge local.config.yml
-if File.exist?(local_config)
-  lconfig = YAML::load_file(local_config)
-  vconfig = vconfig.merge lconfig
-end
-
-# Replace variables in YAML config.
-vconfig.each do |key, value|
-  while vconfig[key].is_a?(String) && vconfig[key].match(/{{ .* }}/)
-    vconfig[key] = vconfig[key].gsub(/{{ (.*?) }}/) { |match| match = vconfig[$1] }
-  end
-end
-
-hostname = vconfig['beet_domain']
-
-Vagrant.configure("2") do |config|
-
-  # Check for plugins and attempt to install if not (Windows only).
-  if vconfig['vagrant_ip'] == "0.0.0.0" && Vagrant::Util::Platform.windows?
-    # Check for plugins and attempt to install if not.
-    %x(vagrant plugin install vagrant-hostsupdater) unless Vagrant.has_plugin?('vagrant-hostsupdater')
-    %x(vagrant plugin install vagrant-auto_network) unless Vagrant.has_plugin?('vagrant-auto_network')
-    raise 'Your config requires hostsupdater plugin.' unless Vagrant.has_plugin?('vagrant-hostsupdater')
-    raise 'Your config requires auto_network plugin.' unless Vagrant.has_plugin?('vagrant-auto_network')
+  if !File.exist?(vagrant_config)
+    # Create default config file.
+    require 'fileutils'
+    FileUtils::mkdir_p config_dir
+    File.open(vagrant_config, "w+") {|f| f.write("---\nbeet_domain: #{vconfig['beet_domain']}\n") }
   end
 
-  config.vm.box = "DrupalMel/beetbox"
-  config.vm.box_version = ">= 0.1.18"
-  config.vm.hostname = hostname
-  config.ssh.insert_key = false
-  config.ssh.forward_agent = true
+  vconfig = vconfig.merge YAML::load_file(vagrant_config)
 
-  # Network config.
-  if vconfig['vagrant_ip'] == "0.0.0.0" && Vagrant::Util::Platform.windows?
-    config.vm.network :private_network, :ip => "0.0.0.0", :auto_network => true
-  elsif vconfig['vagrant_ip'] == "0.0.0.0"
-    config.vm.network :private_network, :type => "dhcp"
-  else
-    config.vm.network :private_network, ip: vconfig['vagrant_ip']
-  end
-
-  # Synced folders.
-  config.vm.synced_folder ".", vconfig['beet_base'],
-    type: "nfs",
-    id: "drupal"
-
-  if vconfig['beet_debug']
-    config.vm.synced_folder "./ansible", "#{vconfig['beet_home']}/ansible",
-      type: "nfs",
-      id: "ansible"
-    debug_mode = "BEETBOX_DEBUG=true"
-  end
-
-  # Upload vagrant.config.yml
-  config.vm.provision "vagrant_config", type: "file" do |s|
-   s.source = vagrant_config
-   s.destination = "#{vconfig['beet_home']}/ansible/vagrant.config.yml"
-  end
-
-  # Upload local.config.yml
+  # Merge local.config.yml
   if File.exist?(local_config)
-    config.vm.provision "local_config", type: "file" do |s|
-     s.source = local_config
-     s.destination = "#{vconfig['beet_home']}/ansible/local.config.yml"
+    lconfig = YAML::load_file(local_config)
+    vconfig = vconfig.merge lconfig
+  end
+
+  # Replace variables in YAML config.
+  vconfig.each do |key, value|
+    while vconfig[key].is_a?(String) && vconfig[key].match(/{{ .* }}/)
+      vconfig[key] = vconfig[key].gsub(/{{ (.*?) }}/) { |match| match = vconfig[$1] }
     end
   end
 
-  # Provision box
-  config.vm.provision "ansible", type: "shell" do |s|
-    s.privileged = true
-    s.inline = "chmod +x #{vconfig['beet_home']}/ansible/build.sh && #{debug_mode} #{vconfig['beet_home']}/ansible/build.sh"
-  end
+  hostname = vconfig['beet_domain']
 
-  # VirtualBox.
-  config.vm.provider :virtualbox do |v|
-    v.name = "#{config.vm.hostname}.#{Time.now.to_i}"
-    v.memory = vconfig['vagrant_memory']
-    v.cpus = vconfig['vagrant_cpus']
-    v.linked_clone = true
-    v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
-    v.customize ["modifyvm", :id, "--ioapic", "on"]
-  end
-end
+  Vagrant.configure("2") do |config|
 
-# Create local drush alias.
-if File.directory?("#{Dir.home}/.drush")
-  alias_file = "#{Dir.home}/.drush/" + hostname + ".aliases.drushrc.php"
-  if ARGV[0] == "destroy"
-    File.delete(alias_file) if File.exist?(alias_file)
-  else
-    require 'erb'
-    class DrushAlias
-      attr_accessor :hostname, :uri, :key, :root
-      def template_binding
-        binding
+    # Check for plugins and attempt to install if not (Windows only).
+    if vconfig['vagrant_ip'] == "0.0.0.0" && Vagrant::Util::Platform.windows?
+      # Check for plugins and attempt to install if not.
+      %x(vagrant plugin install vagrant-hostsupdater) unless Vagrant.has_plugin?('vagrant-hostsupdater')
+      %x(vagrant plugin install vagrant-auto_network) unless Vagrant.has_plugin?('vagrant-auto_network')
+      raise 'Your config requires hostsupdater plugin.' unless Vagrant.has_plugin?('vagrant-hostsupdater')
+      raise 'Your config requires auto_network plugin.' unless Vagrant.has_plugin?('vagrant-auto_network')
+    end
+
+    config.vm.box = "DrupalMel/beetbox"
+    config.vm.box_version = ">= 0.1.18"
+    config.vm.hostname = hostname
+    config.ssh.insert_key = false
+    config.ssh.forward_agent = true
+
+    # Network config.
+    if vconfig['vagrant_ip'] == "0.0.0.0" && Vagrant::Util::Platform.windows?
+      config.vm.network :private_network, :ip => "0.0.0.0", :auto_network => true
+    elsif vconfig['vagrant_ip'] == "0.0.0.0"
+      config.vm.network :private_network, :type => "dhcp"
+    else
+      config.vm.network :private_network, ip: vconfig['vagrant_ip']
+    end
+
+    # Synced folders.
+    config.vm.synced_folder ".", vconfig['beet_base'],
+      type: "nfs",
+      id: "drupal"
+
+    if vconfig['beet_debug']
+      config.vm.synced_folder "./ansible", "#{vconfig['beet_home']}/ansible",
+        type: "nfs",
+        id: "ansible"
+      debug_mode = "BEETBOX_DEBUG=true"
+    end
+
+    # Upload vagrant.config.yml
+    config.vm.provision "vagrant_config", type: "file" do |s|
+     s.source = vagrant_config
+     s.destination = "#{vconfig['beet_home']}/ansible/vagrant.config.yml"
+    end
+
+    # Upload local.config.yml
+    if File.exist?(local_config)
+      config.vm.provision "local_config", type: "file" do |s|
+       s.source = local_config
+       s.destination = "#{vconfig['beet_home']}/ansible/local.config.yml"
       end
     end
 
-    template_file = File.dirname(File.expand_path(__FILE__)) + '/drush.alias.erb'
-    template = File.read(template_file)
+    # Provision box
+    config.vm.provision "ansible", type: "shell" do |s|
+      s.privileged = true
+      s.inline = "chmod +x #{vconfig['beet_home']}/ansible/build.sh && #{debug_mode} #{vconfig['beet_home']}/ansible/build.sh"
+    end
 
-    alias_file = File.open(alias_file, "w+")
-    da = DrushAlias.new
-    da.hostname = hostname
-    da.uri = hostname
-    da.key = "#{Dir.home}/.vagrant.d/insecure_private_key"
-    da.root = vconfig['beet_web'] ||= vconfig['beet_root'] ||= vconfig['beet_base']
-    alias_file << ERB.new(template).result(da.template_binding)
-    alias_file.close
+    # VirtualBox.
+    config.vm.provider :virtualbox do |v|
+      v.name = "#{config.vm.hostname}.#{Time.now.to_i}"
+      v.memory = vconfig['vagrant_memory']
+      v.cpus = vconfig['vagrant_cpus']
+      v.linked_clone = true
+      v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+      v.customize ["modifyvm", :id, "--ioapic", "on"]
+    end
+  end
+
+  # Create local drush alias.
+  if File.directory?("#{Dir.home}/.drush")
+    alias_file = "#{Dir.home}/.drush/" + hostname + ".aliases.drushrc.php"
+    if ARGV[0] == "destroy"
+      File.delete(alias_file) if File.exist?(alias_file)
+    else
+      require 'erb'
+      class DrushAlias
+        attr_accessor :hostname, :uri, :key, :root
+        def template_binding
+          binding
+        end
+      end
+
+      template_file = File.dirname(File.expand_path(__FILE__)) + '/drush.alias.erb'
+      template = File.read(template_file)
+
+      alias_file = File.open(alias_file, "w+")
+      da = DrushAlias.new
+      da.hostname = hostname
+      da.uri = hostname
+      da.key = "#{Dir.home}/.vagrant.d/insecure_private_key"
+      da.root = vconfig['beet_web'] ||= vconfig['beet_root'] ||= vconfig['beet_base']
+      alias_file << ERB.new(template).result(da.template_binding)
+      alias_file.close
+    end
   end
 end

--- a/packer/includes/Vagrantfile
+++ b/packer/includes/Vagrantfile
@@ -14,10 +14,10 @@ end
 # Determine the current working directory.
 cwd = nil
 if id != nil
-  cwd = /#{id}.*?(\/.*?)\n/.match(`vagrant global-status`)[1]
+  cwd = /#{id}.*?(\/.*?)\n/.match(`vagrant global-status`)[1].strip
 else
   paths = Dir.pwd.split('/')
-  while cwd == nil
+  while cwd == nil && !paths.empty?
     dir = paths.join('/')
     current = paths.pop
     if File.exists?("#{dir}/VagrantFile")
@@ -28,10 +28,7 @@ end
 
 # Ensure project Vagrantfile hasn't been customized.
 # @TODO - Add secondary check that parses the Vagrantfile if the MD5 is changed.
-md5 = Digest::MD5.file("#{dir}/VagrantFile").hexdigest
-if md5 == "abef0f6a03cc23bb3da842cd1d12aa50"
-  hostname = cwd.split('/').last.gsub(/[\._]/, '-') + ".local"
-
+if cwd != nil && Digest::MD5.file("#{cwd}/VagrantFile").hexdigest == "abef0f6a03cc23bb3da842cd1d12aa50"
   config_dir = '.beetbox/'
   vagrant_config = "#{cwd}/#{config_dir}config.yml"
   local_config = "#{cwd}/#{config_dir}local.config.yml"
@@ -43,7 +40,7 @@ if md5 == "abef0f6a03cc23bb3da842cd1d12aa50"
     'vagrant_cpus' => 2,
     'beet_home' => '/beetbox',
     'beet_base' => '/var/beetbox',
-    'beet_domain' => hostname
+    'beet_domain' => cwd.split('/').last.gsub(/[\._]/, '-') + ".local"
   }
 
   if !File.exist?(vagrant_config)

--- a/packer/includes/Vagrantfile
+++ b/packer/includes/Vagrantfile
@@ -1,0 +1,163 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+require 'yaml'
+
+Vagrant.require_version '>= 1.8.0'
+
+# Find the Vagrant ID if supplied.
+id = nil
+ARGV.each do |arg|
+  id = arg[/\h{7}/] ? arg : id
+end
+
+# Determine the current working directory.
+cwd = nil
+if id != nil
+  cwd = /#{id}.*?(\/.*?)\n/.match(`vagrant global-status`)[1]
+else
+  paths = Dir.pwd.split('/')
+  while cwd == nil
+    dir = paths.join('/')
+    current = paths.pop
+    if File.exists?("#{dir}/VagrantFile")
+      cwd = dir
+    end
+  end
+end
+hostname = cwd.split('/').last.gsub(/[\._]/, '-') + ".local"
+
+config_dir = '.beetbox/'
+vagrant_config = "#{cwd}/#{config_dir}config.yml"
+local_config = "#{cwd}/#{config_dir}local.config.yml"
+
+# Default vagrant config.
+vconfig = {
+  'vagrant_ip' => '0.0.0.0',
+  'vagrant_memory' => 1024,
+  'vagrant_cpus' => 2,
+  'beet_home' => '/beetbox',
+  'beet_base' => '/var/beetbox',
+  'beet_domain' => hostname
+}
+
+if !File.exist?(vagrant_config)
+  # Create default config file.
+  require 'fileutils'
+  FileUtils::mkdir_p config_dir
+  File.open(vagrant_config, "w+") {|f| f.write("---\nbeet_domain: #{vconfig['beet_domain']}\n") }
+end
+
+vconfig = vconfig.merge YAML::load_file(vagrant_config)
+
+# Merge local.config.yml
+if File.exist?(local_config)
+  lconfig = YAML::load_file(local_config)
+  vconfig = vconfig.merge lconfig
+end
+
+# Replace variables in YAML config.
+vconfig.each do |key, value|
+  while vconfig[key].is_a?(String) && vconfig[key].match(/{{ .* }}/)
+    vconfig[key] = vconfig[key].gsub(/{{ (.*?) }}/) { |match| match = vconfig[$1] }
+  end
+end
+
+hostname = vconfig['beet_domain']
+
+Vagrant.configure("2") do |config|
+
+  # Check for plugins and attempt to install if not (Windows only).
+  if vconfig['vagrant_ip'] == "0.0.0.0" && Vagrant::Util::Platform.windows?
+    # Check for plugins and attempt to install if not.
+    %x(vagrant plugin install vagrant-hostsupdater) unless Vagrant.has_plugin?('vagrant-hostsupdater')
+    %x(vagrant plugin install vagrant-auto_network) unless Vagrant.has_plugin?('vagrant-auto_network')
+    raise 'Your config requires hostsupdater plugin.' unless Vagrant.has_plugin?('vagrant-hostsupdater')
+    raise 'Your config requires auto_network plugin.' unless Vagrant.has_plugin?('vagrant-auto_network')
+  end
+
+  config.vm.box = "DrupalMel/beetbox"
+  config.vm.box_version = ">= 0.1.18"
+  config.vm.hostname = hostname
+  config.ssh.insert_key = false
+  config.ssh.forward_agent = true
+
+  # Network config.
+  if vconfig['vagrant_ip'] == "0.0.0.0" && Vagrant::Util::Platform.windows?
+    config.vm.network :private_network, :ip => "0.0.0.0", :auto_network => true
+  elsif vconfig['vagrant_ip'] == "0.0.0.0"
+    config.vm.network :private_network, :type => "dhcp"
+  else
+    config.vm.network :private_network, ip: vconfig['vagrant_ip']
+  end
+
+  # Synced folders.
+  config.vm.synced_folder ".", vconfig['beet_base'],
+    type: "nfs",
+    id: "drupal"
+
+  if vconfig['beet_debug']
+    config.vm.synced_folder "./ansible", "#{vconfig['beet_home']}/ansible",
+      type: "nfs",
+      id: "ansible"
+    debug_mode = "BEETBOX_DEBUG=true"
+  end
+
+  # Upload vagrant.config.yml
+  config.vm.provision "vagrant_config", type: "file" do |s|
+   s.source = vagrant_config
+   s.destination = "#{vconfig['beet_home']}/ansible/vagrant.config.yml"
+  end
+
+  # Upload local.config.yml
+  if File.exist?(local_config)
+    config.vm.provision "local_config", type: "file" do |s|
+     s.source = local_config
+     s.destination = "#{vconfig['beet_home']}/ansible/local.config.yml"
+    end
+  end
+
+  # Provision box
+  config.vm.provision "ansible", type: "shell" do |s|
+    s.privileged = true
+    s.inline = "chmod +x #{vconfig['beet_home']}/ansible/build.sh && #{debug_mode} #{vconfig['beet_home']}/ansible/build.sh"
+  end
+
+  # VirtualBox.
+  config.vm.provider :virtualbox do |v|
+    v.name = "#{config.vm.hostname}.#{Time.now.to_i}"
+    v.memory = vconfig['vagrant_memory']
+    v.cpus = vconfig['vagrant_cpus']
+    v.linked_clone = true
+    v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+    v.customize ["modifyvm", :id, "--ioapic", "on"]
+  end
+end
+
+# Create local drush alias.
+if File.directory?("#{Dir.home}/.drush")
+  alias_file = "#{Dir.home}/.drush/" + hostname + ".aliases.drushrc.php"
+  if ARGV[0] == "destroy"
+    File.delete(alias_file) if File.exist?(alias_file)
+  else
+    require 'erb'
+    class DrushAlias
+      attr_accessor :hostname, :uri, :key, :root
+      def template_binding
+        binding
+      end
+    end
+
+    template_file = File.dirname(File.expand_path(__FILE__)) + '/drush.alias.erb'
+    template = File.read(template_file)
+
+    alias_file = File.open(alias_file, "w+")
+    da = DrushAlias.new
+    da.hostname = hostname
+    da.uri = hostname
+    da.key = "#{Dir.home}/.vagrant.d/insecure_private_key"
+    da.root = vconfig['beet_web'] ||= vconfig['beet_root'] ||= vconfig['beet_base']
+    alias_file << ERB.new(template).result(da.template_binding)
+    alias_file.close
+  end
+end

--- a/packer/includes/drush.alias.erb
+++ b/packer/includes/drush.alias.erb
@@ -1,0 +1,9 @@
+<?php
+
+$aliases['<%= @hostname %>'] = array(
+   'uri' => '<%= @uri %>',
+   'remote-host' => '<%= @uri %>',
+   'remote-user' => 'vagrant',
+   'ssh-options' => '-i <%= @key %> -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no',
+   'root' => '<%= @root %>',
+);

--- a/packer/template-12.04.json
+++ b/packer/template-12.04.json
@@ -69,6 +69,10 @@
       {
         "type": "vagrant",
         "compression_level": 9,
+        "vagrantfile_template": "includes/Vagrantfile",
+        "include": [
+          "includes/drush.alias.erb"
+        ],
         "output": "{{user `atlas_username`}}-{{user `atlas_name`}}-{{.Provider}}.box"
       },
       {

--- a/packer/template-14.04.json
+++ b/packer/template-14.04.json
@@ -69,6 +69,10 @@
       {
         "type": "vagrant",
         "compression_level": 9,
+        "vagrantfile_template": "includes/Vagrantfile",
+        "include": [
+          "includes/drush.alias.erb"
+        ],
         "output": "{{user `atlas_username`}}-{{user `atlas_name`}}-{{.Provider}}.box"
       },
       {

--- a/packer/template.json
+++ b/packer/template.json
@@ -69,6 +69,10 @@
       {
         "type": "vagrant",
         "compression_level": 9,
+        "vagrantfile_template": "includes/Vagrantfile",
+        "include": [
+          "includes/drush.alias.erb"
+        ],
         "output": "{{user `atlas_username`}}-{{user `atlas_name`}}-{{.Provider}}.box"
       },
       {


### PR DESCRIPTION
As per epic repeated discussion on Slack, the following changes will supply a default Vagrantfile with the Beetbox base box.

With this change, when running `vagrant init DrupalMel/beetbox` and not modifying the contents of the automatically generated Vagrantfile, when running `vagrant up` a `.beetbox/config.yml` file will be generated in the root of the project containing the `beetbox_domain` variable with a value determined based on the containing directory.

Any changes to the Vagrantfile will entirely override the pre-packaged Vagrantfile, giving full control to the project Vagrantfile.

Future improvements to this PR include:
- Determine if the project Vagranfile was modified by parsing the configuration rather than using an MD5 hash comparison.
- Determine the `beet_project` variable (potentially by analysing the MD5 of any index.php files?).
- Provide relevant default config based on the `beet_project` (If Drupal, does the site need to be installed?, etc).
