### PR TITLE
Make default db beetbox.

### DIFF
--- a/.beetbox/config.yml
+++ b/.beetbox/config.yml
@@ -8,6 +8,7 @@ vagrant_cpus: 2
 beet_project: drupal
 beet_domain: "beetbox.local"
 beet_root: "{{ beet_base }}/projects/{{ beet_project }}"
+beet_mysql_database: "beetbox_{{ beet_project }}"
 beet_site_name: "Beetbox"
 
 # Drupal settings.

--- a/ansible/beetbox.config.yml
+++ b/ansible/beetbox.config.yml
@@ -23,7 +23,7 @@ beet_site_name: "Beetbox"
 beet_webserver: apache
 beet_mysql_user: beetbox
 beet_mysql_password: beetbox
-beet_mysql_database: "beetbox_{{ beet_project }}"
+beet_mysql_database: "beetbox"
 
 # Ansible Galaxy roles.
 galaxy_roles:


### PR DESCRIPTION
This seems to be the last remaining default which caters more for the default project.

It would make more sense that the default db is `beetbox` so the db, username and password are all the same.
