### PR TITLE
Allow environment vars to override defaults.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -114,7 +114,7 @@ Vagrant.configure("2") do |config|
 
       # Provision box
       node.vm.provision "ansible", type: "shell" do |s|
-        s.privileged = true
+        s.privileged = false
         s.inline = "chmod +x #{vconfig['beet_home']}/ansible/build.sh && #{debug_mode} #{vconfig['beet_home']}/ansible/build.sh"
       end
 

--- a/ansible/beetbox.config.yml
+++ b/ansible/beetbox.config.yml
@@ -9,13 +9,14 @@
 # Beetbox config.
 beet_repo: https://github.com/DrupalMel/beetbox.git
 beet_version: "HEAD"
-beet_home: /beetbox
+beet_home: "{{ lookup('env','BEET_HOME') | default('/beetbox',true) }}"
 beet_role_dir: "{{ beet_home }}/ansible/roles"
 beet_project: drupal
 beet_keep_updated: no
 beet_debug: no
 beet_domain: "beetbox.local"
-beet_base: "/var/beetbox"
+beet_user: "{{ lookup('env','BEET_USER') | default('vagrant',true) }}"
+beet_base: "{{ lookup('env','BEET_BASE') | default('/var/beetbox',true) }}"
 beet_root: "{{ beet_base }}"
 beet_web: "{{ beet_root }}"
 beet_ssh_home: "{{ beet_root }}"
@@ -192,9 +193,8 @@ php_packages:
 # Composer config.
 composer_path: /usr/bin/composer
 composer_home_path: '/home/vagrant/.composer'
-composer_home_owner: vagrant
-composer_home_group: vagrant
-# Composer global packages.
+composer_home_owner: "{{ beet_user }}"
+composer_home_group: "{{ beet_user }}"
 # composer_global_packages:
 #   - { name: phpunit/phpunit, release: '@stable' }
 

--- a/ansible/build.sh
+++ b/ansible/build.sh
@@ -27,5 +27,5 @@ ansible-playbook $DEBUG "$currentDir/playbook-roles.yml" -i 'localhost,'
 ansible-playbook $DEBUG "$currentDir/playbook-provision.yml" -i 'localhost,'
 
 # Print welcome message.
-touch /home/vagrant/welcome.txt
-cat /home/vagrant/welcome.txt
+touch ~/welcome.txt
+cat ~/welcome.txt

--- a/ansible/playbook-provision.yml
+++ b/ansible/playbook-provision.yml
@@ -1,7 +1,6 @@
 ---
 - hosts: localhost
   connection: local
-  user: root
   become: yes
 
   vars_files:
@@ -41,6 +40,7 @@
     - name: Create welcome message.
       template:
         src: ../templates/welcome.txt.j2
-        dest: "/home/vagrant/welcome.txt"
+        dest: "~/welcome.txt"
         force: yes
         mode: 0644
+      become: no

--- a/ansible/playbook-roles.yml
+++ b/ansible/playbook-roles.yml
@@ -1,7 +1,6 @@
 ---
 - hosts: localhost
   connection: local
-  user: root
   become: yes
 
   vars_files:
@@ -15,7 +14,7 @@
     - name: Install Galaxy roles
       command: >
         ansible-galaxy install {{ item.name }} -p {{ beet_role_dir }}
-        creates={{ beet_role_dir }}/{{ item.name }}/meta/main.yml
+        creates={{ beet_role_dir }}/{{ item.name }}
       with_items: galaxy_roles
 
     - name: Update Galaxy roles

--- a/ansible/playbook-update.yml
+++ b/ansible/playbook-update.yml
@@ -1,7 +1,6 @@
 ---
 - hosts: localhost
   connection: local
-  user: root
   become: yes
 
   vars_files:
@@ -12,10 +11,12 @@
 
   tasks:
 
-    - name: Create vagrant user.
+    - name: Create {{ beet_user }} user.
       user:
-        name: vagrant
+        name: "{{ beet_user }}"
         shell: /bin/bash
+        createhome: yes
+        home: "/home/{{ beet_user }}"
 
     - name: Check for updates.
       git:
@@ -27,11 +28,19 @@
         force: yes
       when: beet_keep_updated and (not beet_debug)
 
-    - name: Set ownership of beetbox directory.
+    - name: Set ownership of beet_home directory.
       file:
         path: "{{ beet_home }}"
-        owner: vagrant
-        group: vagrant
+        owner: "{{ beet_user }}"
+        group: "{{ beet_user }}"
         recurse: yes
         state: directory
-      when: (not beet_debug)
+      failed_when: false
+
+    - name: Set ownership of beet_base directory.
+      file:
+        path: "{{ beet_base }}"
+        owner: "{{ beet_user }}"
+        group: "{{ beet_user }}"
+        state: directory
+      failed_when: false

--- a/ansible/tasks/www.yml
+++ b/ansible/tasks/www.yml
@@ -8,20 +8,25 @@
     - admin
     - dialout
 
-- name: Ensure vagrant user is in admin group.
-  user: "name=vagrant append=yes groups=admin"
+- name: Ensure {{ beet_user }} user is in admin group.
+  user:
+    name: "{{ beet_user }}"
+    append: yes
+    groups: "admin"
 
 - name: Ensure vagrant home directory is present.
   file:
-    path: "/home/vagrant/"
+    path: "/home/{{ beet_user }}/"
     state: directory
-    owner: vagrant
-    group: vagrant
+    owner: "{{ beet_user }}"
+    group: "{{ beet_user }}"
     recurse: true
 
-- name: Ensure www-data user is in dialout group (Debian).
-  user: "name=www-data append=yes groups=dialout"
-  when: ansible_os_family == 'Debian'
+- name: Ensure www-data user is in dialout group.
+  user:
+    name: "www-data"
+    append: yes
+    groups: "dialout"
 
 - name: Set nicer permissions on Apache log directory.
   file:

--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ test:
   override:
     - sudo cp -rf $BEET_HOME/* $BEET_BASE
     - sudo cp ~/$CIRCLE_PROJECT_REPONAME/.beetbox/config.yml $BEET_HOME/ansible/vagrant.config.yml
-    - sudo su -c $BEET_HOME/ansible/build.sh
+    - $BEET_HOME/ansible/build.sh
 deployment:
   dev:
     branch: dev

--- a/tests/dependencies.sh
+++ b/tests/dependencies.sh
@@ -1,13 +1,21 @@
 #!/bin/bash
 
+# Install ansible and remove default packages.
 sudo pip install ansible==2.0.0.2
 sudo apt-get update
 sudo apt-get purge apache2 php5-cli mysql-common mysql-server
 sudo rm -rf /etc/apache2/mods-enabled/*
 
+# Create BEET_BASE if it doesn't exist.
+if [ ! -d "$BEET_BASE" ]; then
+  sudo mkdir -p $BEET_BASE
+fi
+
+# Clone beetbox if BEET_HOME doesn't exist.
 if [ ! -d "$BEET_HOME" ]; then
   sudo apt-get install git
   git clone https://github.com/drupalmel/beetbox.git $BEET_HOME
 fi
 
-sudo su -c $BEET_HOME/ansible/build.sh
+# Provision instance.
+. $BEET_HOME/ansible/build.sh


### PR DESCRIPTION
This PR addresses the issue with vagrant provisioning as the root user.

It will also resolve a few other issues which we currently have workaround tasks in place, these can be fixed up later as we offload more main task to roles.

It also removes the assumption that the vagrant user exists before provisioning as it doesn't on circle CI.

Overrides to beet_home, beet_base & beet_user can be set in config.yml or set as environment vars.

It should also make the migration to circle CI 14.04 easier.
