### PR TITLE
Fix circle CI and non root user issues.

### DIFF
--- a/ansible/playbook-provision.yml
+++ b/ansible/playbook-provision.yml
@@ -39,7 +39,7 @@
 
     - name: Create welcome message.
       template:
-        src: ../templates/welcome.txt.j2
+        src: templates/welcome.txt.j2
         dest: "~/welcome.txt"
         force: yes
         mode: 0644

--- a/ansible/roles/beetbox-drupal/tasks/main.yml
+++ b/ansible/roles/beetbox-drupal/tasks/main.yml
@@ -23,6 +23,5 @@
     {{ drush_path }} --uri=http://{{ beet_domain }}/ user-login
     chdir={{ beet_root }}
   register: drupal_drush_login
-  when: drupal_site.stat.exists
   changed_when: false
   failed_when: false

--- a/ansible/tasks/init.yml
+++ b/ansible/tasks/init.yml
@@ -51,7 +51,7 @@
 
 - name: Set SSH home directory.
   lineinfile:
-    dest: "/home/vagrant/.bashrc"
+    dest: "/home/{{ beet_user }}/.bashrc"
     state: present
     create: yes
     regexp: "^SSH_HOME="

--- a/ansible/tasks/known-hosts.yml
+++ b/ansible/tasks/known-hosts.yml
@@ -5,3 +5,4 @@
     name: "{{ item }}"
     key: "{{ lookup('pipe', 'ssh-keyscan -t rsa ' + item) }}"
   with_items: "{{ known_hosts }}"
+  become: no

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,7 @@ machine:
   environment:
     BEET_HOME: /beetbox
     BEET_BASE: /var/beetbox
+    BEET_USER: ubuntu
 dependencies:
   pre:
     - sudo cp -rf ~/$CIRCLE_PROJECT_REPONAME $BEET_HOME

--- a/tests/dependencies.sh
+++ b/tests/dependencies.sh
@@ -9,6 +9,7 @@ sudo rm -rf /etc/apache2/mods-enabled/*
 # Create BEET_BASE if it doesn't exist.
 if [ ! -d "$BEET_BASE" ]; then
   sudo mkdir -p $BEET_BASE
+  sudo chown -R $BEET_USER:$BEET_USER $BEET_HOME
 fi
 
 # Clone beetbox if BEET_HOME doesn't exist.


### PR DESCRIPTION
Fixing up a few issues from the switch to running the provisioner as sudo vagrant/ubuntu rather than root.

By default all tasks will run as sudo vagrant or vagrant if `become: no` is defined.

This resolves many issues which have required workarounds in a number of roles for example -- the composer role needed the user defined to set the install location, this will no longer be required if the task is run by the `vagrant` user as the current user is assumed.

https://github.com/drupalmel/beetbox/blob/master/ansible/beetbox.config.yml#L195
