### PR TITLE
Allow remote provisioning.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -116,9 +116,12 @@ Vagrant.configure("2") do |config|
 
       # Provision box
       beet_sh = "#{vconfig['beet_home']}/provisioning/beetbox.sh"
+      remote_sh = "https://raw.githubusercontent.com/drupalmel/beetbox/master/provisioning/beetbox.sh"
+      local_provision = "sudo chmod +x #{beet_sh} && sudo -H #{beet_sh}"
+      remote_provision = "sudo apt-get -qq update && curl -fsSL #{remote_sh} | sudo bash"
       node.vm.provision "ansible", type: "shell" do |s|
         s.privileged = false
-        s.inline = "sudo chmod +x #{beet_sh} && #{debug_mode} sudo -H #{beet_sh}"
+        s.inline = "if [ -f #{beet_sh} ]; then #{local_provision}; else #{remote_provision}; fi"
       end
 
       # VirtualBox.


### PR DESCRIPTION
This PR will allow unprovisioned base boxes such as https://atlas.hashicorp.com/ubuntu/boxes/trusty64.
Should also work with https://atlas.hashicorp.com/ubuntu/boxes/precise64

Mainly useful if you don't want something that is pre-provisioned on beetbox, currently it's difficult to disable functionality as the role may have already been run as part of the base build.

This will also give us basic support for other providers VMWare, Parallels, AWS, Digital Ocean etc.

*Note this functionality would be redundant in the box Vagrantfile.
