### PR TITLE
Fix issue with default beet_domain.

### DIFF
--- a/provisioning/ansible/beetbox.config.yml
+++ b/provisioning/ansible/beetbox.config.yml
@@ -13,7 +13,7 @@ beet_home: "{{ lookup('env','BEET_HOME') | default('/beetbox',true) }}"
 beet_role_dir: "{{ beet_home }}/provisioning/ansible/roles"
 beet_project: drupal
 beet_debug: no
-beet_domain: "beetbox.local"
+beet_domain: "{{ ansible_hostname }}.local"
 beet_user: "{{ lookup('env','BEET_USER') | default('vagrant',true) }}"
 beet_base: "{{ lookup('env','BEET_BASE') | default('/var/beetbox',true) }}"
 beet_root: "{{ beet_base }}"


### PR DESCRIPTION
Fixed an issue when there is no `beet_domain` defined in `config.yml` but there is a `config.yml` file.

The issue is that a domain is dynamically generated in the Vagrantfile, but that data is not transmitted to within the box, so during the provisioning stage it assumes the domain is `beetbox.local` instead of what it really is.
