### PR TITLE
Allow beetbox user access to all databases by default.

### DIFF
--- a/provisioning/ansible/config/beetbox.config.yml
+++ b/provisioning/ansible/config/beetbox.config.yml
@@ -104,7 +104,7 @@ mysql_users:
   - name: "{{ beet_mysql_user }}"
     host: "%"
     password: "{{ beet_mysql_password }}"
-    priv: "{{ beet_mysql_database }}.*:ALL"
+    priv: "*.*:ALL"
 
 # Extra utilities form provided roles.
 # Comment out the ones that do not need to be installed.


### PR DESCRIPTION
Leaving this open for general review, current workaround it to set the following in your config.

```
mysql_users:
  - name: "{{ beet_mysql_user }}"
    host: "%"
    password: "{{ beet_mysql_password }}"
    priv: "*.*:ALL"
```
