### PR TITLE
Set permissions on beet_user home and tmp directories.

### DIFF
--- a/provisioning/ansible/playbook-provision.yml
+++ b/provisioning/ansible/playbook-provision.yml
@@ -28,3 +28,12 @@
     - { role: beetbox-symlinks, when: symlinks }
     - { role: beetbox-php-nginx }
     - { role: beetbox-welcome }
+
+  tasks:
+    - name: Set ownership of beet_user home directory.
+      file:
+        path: "/home/{{ beet_user }}"
+        state: directory
+        owner: "{{ beet_user }}"
+        group: "{{ beet_user }}"
+        recurse: yes

--- a/provisioning/ansible/roles/beetbox-web/tasks/main.yml
+++ b/provisioning/ansible/roles/beetbox-web/tasks/main.yml
@@ -10,4 +10,12 @@
     path: "/var/log/{{ apache_daemon }}"
     state: directory
     mode: 0755
-    recurse: true
+    recurse: yes
+
+- name: Set tmp folder permissions.
+  file:
+    path: "/tmp"
+    state: directory
+    owner: root
+    group: root
+    mode: 01777


### PR DESCRIPTION
Resolves drush cache issue and #152 

*note: the new task "Set ownership of beet_user home directory" is only a workaround as we might need some patches upstream to fully resolve.
