### PR TITLE
Fix wrong link to beetbox.config.yml

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,7 +11,7 @@ so any of these YAML attributes could be imported into your project `config.yml`
 php_date_timezone: "Antarctica/South_Pole"
 ```
 
-The full list of ansible roles beetbox implements is here: [https://github.com/beetboxvm/beetbox/blob/master/provisioning/ansible/beetbox.config.yml#L29](https://github.com/beetboxvm/beetbox/blob/master/provisioning/ansible/beetbox.config.yml#L29)
+The full list of ansible roles beetbox implements is here: [https://github.com/beetboxvm/beetbox/blob/master/provisioning/ansible/config/beetbox.config.yml#L29](https://github.com/beetboxvm/beetbox/blob/master/provisioning/ansible/config/beetbox.config.yml#L29)
 
 Beetbox itself has a predefined set of configuration: https://github.com/beetboxvm/beetbox/blob/master/provisioning/ansible/beetbox.config.yml
 so not all attributes are defined inside roles and in some cases role attributes have already been overridden, however your project config will **always** override these settings.


### PR DESCRIPTION
Found the error here: http://beetbox.readthedocs.org/en/stable/configuration/#configuration-from-used-roles
