### PR TITLE
Create and use vagrant user on circle.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,6 @@ machine:
     BEET_BOX: beet/box
     BEET_HOME: /beetbox
     BEET_BASE: /var/beetbox
-    BEET_USER: ubuntu
     BEET_DEPLOY: provisioning/deploy.sh
     BEET_PROVISION: provisioning/beetbox.sh
     VAGRANT_INIT: true

--- a/provisioning/ansible/roles/beetbox-welcome/tasks/main.yml
+++ b/provisioning/ansible/roles/beetbox-welcome/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Create welcome message.
   template:
     src: templates/welcome.txt.j2
-    dest: "~/welcome.txt"
+    dest: "{{ beet_home }}/.beetbox/welcome.txt"
     force: yes
     mode: 0644
   become: no


### PR DESCRIPTION
Allows circle to test as the default `vagrant` user to test and pick up permission issues.
