### PR TITLE
Remove redundant vagrant config.

### DIFF
--- a/.beetbox/config.yml
+++ b/.beetbox/config.yml
@@ -1,8 +1,6 @@
 ---
 # Vagrant config.
 vagrant_ip: 192.168.88.88
-vagrant_memory: 1024
-vagrant_cpus: 2
 
 # Beetbox settings.
 beet_project: drupal


### PR DESCRIPTION
These aren't overrides as they are the same as the default settings.
