### PR TITLE
Update drupal core branch to 8.1.x

### DIFF
--- a/provisioning/ansible/roles/beetbox-drupal/defaults/main.yml
+++ b/provisioning/ansible/roles/beetbox-drupal/defaults/main.yml
@@ -7,6 +7,7 @@ drupal_install_site: no
 drupal_create_makefile: no
 drupal_build_makefile: no
 drupal_makefile_path: "~/beetbox.make.yml"
+drupal_make_core_branch: "8.1.x"
 drupal_distro: no
 drupal_distro_makefile: /vagrant/drupal-org.make.yml
 drupal_build_composer: no

--- a/provisioning/ansible/roles/beetbox-drupal/tasks/build-makefile.yml
+++ b/provisioning/ansible/roles/beetbox-drupal/tasks/build-makefile.yml
@@ -13,6 +13,12 @@
   when: not drupal_site.stat.exists
   become: no
 
+- name: Install Drupal dependencies with composer.
+  composer:
+    command: install
+    working_dir: "{{ beet_root }}"
+  become: no
+
 - name: Remove built distribution files/directories.
   file:
     path: "{{ beet_root }}/profiles/{{ drupal_distro }}/{{ item }}"

--- a/provisioning/ansible/roles/beetbox-drupal/templates/drupal.make.yml.j2
+++ b/provisioning/ansible/roles/beetbox-drupal/templates/drupal.make.yml.j2
@@ -11,7 +11,7 @@ projects:
     type: "core"
     download:
       # Drupal core branch (e.g. "6.x", "7.x", "8.0.x").
-      branch: "8.0.x"
+      branch: "{{ drupal_make_core_branch }}"
       working-copy: true
 
   # Other modules.


### PR DESCRIPTION
Also 8.1.x requires a composer install as external dependencies have been removed from the core repo -- https://www.drupal.org/node/1475510
