### PR TITLE
Added support for multiple domains via beet_aliases var.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,7 +19,8 @@ vconfig = {
   'vagrant_cpus' => 2,
   'beet_home' => '/beetbox',
   'beet_base' => '/var/beetbox',
-  'beet_domain' => cwd.split('/').last.gsub(/[\._]/, '-') + ".local"
+  'beet_domain' => cwd.split('/').last.gsub(/[\._]/, '-') + ".local",
+  'beet_aliases' => []
 }
 
 if !File.exist?(project_config)
@@ -50,6 +51,15 @@ branches = ['beetbox']
 current_branch = 'beetbox'
 
 Vagrant.configure("2") do |config|
+
+  # Hosts file plugins.
+  if Vagrant.has_plugin?('vagrant-hostsupdater')
+    config.hostsupdater.aliases = vconfig['beet_aliases']
+  elsif Vagrant.has_plugin?('vagrant-hostmanager')
+    config.hostmanager.enabled = true
+    config.hostmanager.manage_host = true
+    config.hostmanager.aliases = vconfig['beet_aliases']
+  end
 
   # Multidev config.
   if vconfig['beet_mode'] == 'multidev'

--- a/provisioning/ansible/config/beetbox.config.yml
+++ b/provisioning/ansible/config/beetbox.config.yml
@@ -14,6 +14,7 @@ beet_role_dir: "{{ beet_home }}/provisioning/ansible/roles"
 beet_project: drupal
 beet_debug: no
 beet_domain: "{{ ansible_hostname }}.local"
+beet_aliases: []
 beet_user: "{{ lookup('env','BEET_USER') | default('vagrant',true) }}"
 beet_base: "{{ lookup('env','BEET_BASE') | default('/var/beetbox',true) }}"
 beet_root: "{{ beet_base }}"

--- a/provisioning/ansible/roles/beetbox-init/tasks/main.yml
+++ b/provisioning/ansible/roles/beetbox-init/tasks/main.yml
@@ -1,4 +1,13 @@
 ---
+- name: Add domains and aliases to hosts file.
+  lineinfile:
+    dest: /etc/hosts
+    regexp: '^127\.0\.0\.1'
+    line: "127.0.0.1 localhost {{ beet_domain }} {{ beet_aliases | join(' ') }}"
+    owner: root
+    group: root
+    mode: 0644
+
 - name: Update apt cache if needed.
   apt: update_cache=yes cache_valid_time=86400
   failed_when: false


### PR DESCRIPTION
This PR adds a new var `beet_aliases` this will use either the vagrant-hostsupdater or vagrant-hostmanager plugins to configure additional domains for the VM.
