### PR TITLE
Bump drush version & php_memory_limit.

### DIFF
--- a/.beetbox/config.yml
+++ b/.beetbox/config.yml
@@ -15,6 +15,7 @@ drupal_build_makefile: yes
 drupal_install_site: yes
 drupal_account_name: admin
 drupal_account_pass: admin
+php_memory_limit: "284M"
 
 # Beetbox debug.
 beet_debug: yes

--- a/provisioning/ansible/config/beetbox.config.yml
+++ b/provisioning/ansible/config/beetbox.config.yml
@@ -277,8 +277,8 @@ composer_home_group: "{{ beet_user }}"
 #   - { name: phpunit/phpunit, release: '@stable' }
 
 # Drush config.
-drush_version: "8.0.3"
-drush_keep_updated: "{{ (drush_version != '8.0.3') }}"
+drush_version: "8.1.2"
+drush_keep_updated: "{{ (drush_version != '8.1.2') }}"
 drush_composer_cli_options: "--prefer-dist --no-interaction"
 
 # MySQL config.


### PR DESCRIPTION
8.2.x drush install seems to require a higher memory limit.
