### PR TITLE
#211: Fixed issue with composer and Drupal 7.

### DIFF
--- a/provisioning/ansible/roles/beetbox-drupal/tasks/build-makefile.yml
+++ b/provisioning/ansible/roles/beetbox-drupal/tasks/build-makefile.yml
@@ -13,11 +13,15 @@
   when: not drupal_site.stat.exists
   become: no
 
+- stat:
+    path: "{{ beet_root }}/composer.json"
+  register: composer_file
 - name: Install Drupal dependencies with composer.
   composer:
     command: install
     working_dir: "{{ beet_root }}"
   become: no
+  when: composer_file.stat.exists
 
 - name: Remove built distribution files/directories.
   file:


### PR DESCRIPTION
Adds a check to see if a `composer.json` file exists before running `composer install`.
