### PR TITLE
Disable firewall config by default.

### DIFF
--- a/provisioning/ansible/config/beetbox.config.yml
+++ b/provisioning/ansible/config/beetbox.config.yml
@@ -186,6 +186,7 @@ installed_extras_selenium: "{{ 'selenium' in installed_extras }}"
 installed_extras_drupal_console: "{{ 'drupal-console' in installed_extras }}"
 
 # Disabled by default.
+installed_extras_firewall: "{{ 'firewall' in installed_extras }}"
 installed_extras_postfix: "{{ 'postfix' in installed_extras }}"
 installed_extras_pantheon_cli: "{{ 'pantheon-cli' in installed_extras }}"
 installed_extras_varnish: "{{ 'varnish' in installed_extras }}"
@@ -203,22 +204,6 @@ extra_packages:
   - imagemagick
   - php5-sqlite
   - unzip
-
-# Firewall config.
-firewall_allowed_tcp_ports:
-  - "22"
-  - "25"
-  - "80"
-  - "81"
-  - "443"
-  - "4444"
-  - "8025"
-  - "8080"
-  - "8443"
-  - "8983"
-firewall_allowed_udp_ports:
-  - "5353"
-firewall_log_dropped_packets: false
 
 # git config.
 git_packages:

--- a/provisioning/ansible/roles/beetbox-common/meta/main.yml
+++ b/provisioning/ansible/roles/beetbox-common/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
-  - { role: geerlingguy.firewall}
+  - { role: geerlingguy.firewall, when: "{{ installed_extras_firewall }}" }
   - { role: geerlingguy.git }
   - { role: geerlingguy.apache }
   - { role: geerlingguy.apache-php-fpm }


### PR DESCRIPTION
This firewall role conflicts with most non VM builds eg docker/LXD and as we are never using this to provision publicly accessible servers there's not much value in having this enabled by default. 
