### PR TITLE
Turn-off RDP Server for VirtualBox machines

### DIFF
--- a/.beetbox/Vagrantfile
+++ b/.beetbox/Vagrantfile
@@ -152,8 +152,11 @@ Vagrant.configure("2") do |config|
         v.memory = vconfig['vagrant_memory']
         v.cpus = vconfig['vagrant_cpus']
         v.linked_clone = true
-        v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
-        v.customize ["modifyvm", :id, "--ioapic", "on"]
+        v.customize ["modifyvm", :id,
+          "--natdnshostresolver1", "on",
+          "--ioapic", "on",
+          "--vrde", "off"
+        ]
       end
     end
   end


### PR DESCRIPTION
## Problem

Having RDP turned on in the beetbox VirtualBox base box shows up as a warning…

> Invalid settings detected 
> **Display: Remote Display** page

…when provisioning a new beetbox VM with the current base box. See the screenshot at _Fig. 1_.
## Suggested Solution

You should either 
1. Address this in the build script for your base box, wherever that is.
2. Add new `vboxmanage` configuration line to the Vagrantfile (as done in the PR). 
## Related Links
- [VirtualBox Manual 7.1. Remote display (VRDP support)](https://www.virtualbox.org/manual/ch07.html)
## References
- **Fig. 1**
  ![Beetbox Invalid Settings Detected](https://cloud.githubusercontent.com/assets/452515/16065173/8fb35598-32eb-11e6-8401-5219c22615ef.png)
