### PR TITLE
Disable selenium by default.

### DIFF
--- a/provisioning/ansible/config/beetbox.config.yml
+++ b/provisioning/ansible/config/beetbox.config.yml
@@ -177,12 +177,12 @@ installed_extras_mailhog: yes
 installed_extras_memcached: yes
 installed_extras_xdebug: yes
 installed_extras_xhprof: yes
-installed_extras_selenium: yes
 installed_extras_drupal_console: yes
 installed_extras_drush: yes
 installed_extras_upload_progress: yes
 
 # Disabled by default.
+installed_extras_selenium: no
 installed_extras_firewall: no
 installed_extras_postfix: no
 installed_extras_pantheon_cli: no


### PR DESCRIPTION
base box size is creeping up again -- https://atlas.hashicorp.com/beet/boxes/dev

Would recommend we drop selenium which has a dependency on java.

I'm making use of phantomjs which is a lot faster than selenium and we have a role for it -- https://github.com/beetboxvm/ansible-role-beetbox-phantomjs
