### PR TITLE
Disable alias by default.

### DIFF
--- a/.beetbox/Vagrantfile
+++ b/.beetbox/Vagrantfile
@@ -25,7 +25,7 @@ vconfig = {
   'beet_domain' => beet_root.split('/').last.gsub(/[\._]/, '-') + ".local",
   'beet_aliases' => [],
   'beet_provision' => true,
-  'drush_create_alias' => true
+  'drush_create_alias' => false
 }
 
 # Create default config file.

--- a/.beetbox/config.yml
+++ b/.beetbox/config.yml
@@ -15,6 +15,7 @@ drupal_build_makefile: yes
 drupal_install_site: yes
 drupal_account_name: admin
 drupal_account_pass: admin
+drush_create_alias: yes
 php_memory_limit: "284M"
 
 # Beetbox debug.


### PR DESCRIPTION
I'd like to propose we disable this by default.

I'm no longer using it on any Drupal projects as I add aliases directly to the project to be version controlled.
