### PR TITLE
Add tags to provision playbook.

### DIFF
--- a/.beetbox/Vagrantfile
+++ b/.beetbox/Vagrantfile
@@ -19,6 +19,7 @@ vconfig = {
   'vagrant_memory' => 1024,
   'vagrant_cpus' => 2,
   'beet_provision_playbook' => 'provision',
+  'beet_provision_tags' => 'all',
   'beet_home' => '/beetbox',
   'beet_base' => '/var/beetbox',
   'beet_domain' => beet_root.split('/').last.gsub(/[\._]/, '-') + ".local",
@@ -138,7 +139,8 @@ Vagrant.configure("2") do |config|
       # Provision box
       beet_sh = "#{vconfig['beet_home']}/provisioning/beetbox.sh"
       beet_sh_playbook = ENV['BEET_PLAY'] || "#{vconfig['beet_provision_playbook']}"
-      local_provision = "sudo chmod +x #{beet_sh} && #{debug_mode} #{beet_sh} #{beet_sh_playbook}"
+      beet_sh_tags = ENV['BEET_TAGS'] || "#{vconfig['beet_provision_tags']}"
+      local_provision = "sudo chmod +x #{beet_sh} && #{debug_mode} #{beet_sh} #{beet_sh_playbook} #{beet_sh_tags}"
       remote_provision = "sudo apt-get -y install curl && curl -fsSL http://bit.ly/beetbuild | UBUNTU_INIT=true bash -Ee"
       node.vm.provision "ansible", type: "shell" do |s|
         s.privileged = false

--- a/provisioning/ansible/playbook-provision.yml
+++ b/provisioning/ansible/playbook-provision.yml
@@ -18,130 +18,193 @@
     - include: "{{ item }}"
       with_fileglob:
         - "{{ beet_custom_pre_tasks }}"
+      tags:
+        - pre
+        - custom
 
   roles:
     - role: beetbox-init
       when: "{{ installed_extras_init }}"
-    - role: beetboxvm.known-hosts
-      when: "{{ known_hosts }}"
-    - role: geerlingguy.firewall
-      when: "{{ installed_extras_firewall }}"
-    - role: geerlingguy.git
-      when: "{{ installed_extras_git }}"
+      tags: beetbox
     - role: geerlingguy.apache
       when: "{{ installed_extras_apache }}"
+      tags: beetbox
     - role: geerlingguy.apache-php-fpm
       when: "{{ installed_extras_php }}"
+      tags: beetbox
     - role: geerlingguy.nginx
       when: "{{ installed_extras_nginx }}"
+      tags: beetbox
     - role: geerlingguy.mysql
       when: "{{ installed_extras_mysql }}"
+      tags: beetbox
     - role: beetbox-php-ppa
       when: "{{ installed_extras_php }}"
+      tags: beetbox
     - role: beetbox-php-7.0
       when: "'{{ installed_extras_php }}' and '{{ php_version }}' == '7.0'"
+      tags: beetbox
     - role: geerlingguy.php
       when: "{{ installed_extras_php }}"
+      tags: beetbox
     - role: geerlingguy.php-pecl
       when: "{{ installed_extras_pecl }}"
+      tags: beetbox
     - role: geerlingguy.php-mysql
       when: "{{ installed_extras_mysql }}"
+      tags: beetbox
     - role: geerlingguy.composer
       when: "{{ installed_extras_composer }}"
+      tags: beetbox
     - role: pwelch.avahi
       when: "{{ installed_extras_avahi }}"
+    - role: beetboxvm.known-hosts
+      when: "{{ known_hosts }}"
+      tags: extras
+    - role: geerlingguy.firewall
+      when: "{{ installed_extras_firewall }}"
+      tags: extras
+    - role: geerlingguy.git
+      when: "{{ installed_extras_git }}"
+      tags: extras
     - role: angstwad.docker_ubuntu
       when: "{{ installed_extras_docker }}"
+      tags: extras
     - role: thebinary.lxd
       when: "{{ installed_extras_lxd }}"
+      tags: extras
     - role: ANXS.postgresql
       when: "{{ installed_extras_postgresql }}"
+      tags: extras
     - role: geerlingguy.memcached
       when: "{{ installed_extras_memcached }}"
+      tags: extras
     - role: geerlingguy.php-memcached
       when: "{{ installed_extras_memcached }}"
+      tags: extras
     - role: geerlingguy.drush
       when: "{{ installed_extras_drush }}"
+      tags: extras
     - role: geerlingguy.drupal-console
       when: "{{ installed_extras_drupal_console }}"
+      tags: extras
     - role: thom8.php-upload-progress
       when: "{{ installed_extras_upload_progress }}"
+      tags: extras
     - role: geerlingguy.php-xdebug
       when: "{{ installed_extras_xdebug }}"
+      tags: extras
     - role: geerlingguy.php-xhprof
       when: "{{ installed_extras_xhprof }}"
+      tags: extras
     - role: geerlingguy.blackfire
       when: "{{ installed_extras_blackfire }}"
+      tags: extras
     - role: geerlingguy.adminer
       when: "{{ installed_extras_adminer }}"
+      tags: extras
     - role: geerlingguy.pimpmylog
       when: "{{ installed_extras_pimpmylog }}"
+      tags: extras
     - role: geerlingguy.daemonize
       when: "{{ installed_extras_mailhog }}"
+      tags: extras
     - role: geerlingguy.postfix
       when: "{{ installed_extras_postfix }}"
+      tags: extras
     - role: geerlingguy.mailhog
       when: "{{ installed_extras_mailhog }}"
+      tags: extras
     - role: franklinkim.newrelic
       when: "{{ installed_extras_newrelic }}"
+      tags: extras
     - role: geerlingguy.nodejs
       when: "{{ installed_extras_nodejs }}"
+      tags: extras
     - role: geerlingguy.redis
       when: "{{ installed_extras_redis }}"
+      tags: extras
     - role: geerlingguy.php-redis
       when: "{{ installed_extras_redis }}"
+      tags: extras
     - role: geerlingguy.ruby
       when: "{{ installed_extras_ruby }}"
+      tags: extras
     - role: rvm_io.rvm1-ruby
       when: "{{ installed_extras_rvm }}"
+      tags: extras
     - role: geerlingguy.java
       when: "{{ installed_extras_solr }} or {{ installed_extras_selenium }} or {{ installed_extras_elasticsearch }}"
+      tags: extras
     - role: geerlingguy.solr
       when: "{{ installed_extras_solr }}"
+      tags: extras
     - role: arknoll.selenium
       when: "{{ installed_extras_selenium }}"
+      tags: extras
     - role: geerlingguy.elasticsearch
       when: "{{ installed_extras_elasticsearch }}"
+      tags: extras
     - role: geerlingguy.varnish
       when: "{{ installed_extras_varnish }}"
+      tags: extras
     - role: hashbangcode.pantheon-cli
       when: "{{ installed_extras_pantheon_cli }}"
+      tags: extras
     - role: beetboxvm.phantomjs
       when: "{{ installed_extras_phantomjs }}"
+      tags: extras
     - role: heskethm.wp-cli
       when: "{{ installed_extras_wp_cli }}"
-    - role: beetboxvm.drupal
-      when: "'{{ beet_project }}' == 'drupal'"
-    - role: beetboxvm.backdrop
-      when: "'{{ beet_project }}' == 'backdrop'"
-    - role: beetboxvm.cakephp
-      when: "'{{ beet_project }}' == 'cakephp'"
-    - role: beetboxvm.concrete5
-      when: "'{{ beet_project }}' == 'concrete5'"
-    - role: beetboxvm.kohana
-      when: "'{{ beet_project }}' == 'kohana'"
-    - role: beetboxvm.modx
-      when: "'{{ beet_project }}' == 'modx'"
-    - role: beetboxvm.silverstripe
-      when: "'{{ beet_project }}' == 'silverstripe'"
-    - role: beetboxvm.slim
-      when: "'{{ beet_project }}' == 'slim'"
-    - role: beetboxvm.symfony
-      when: "'{{ beet_project }}' == 'symfony'"
-    - role: beetboxvm.wordpress
-      when: "'{{ beet_project }}' == 'wordpress'"
-    - role: beetboxvm.packages
-      when: "{{ extra_packages }}"
-    - role: beetbox-web
-      when: "{{ installed_extras_web }}"
-    - role: beetbox-apparmor
-      when: "{{ installed_extras_apparmor }}"
-    - role: beetboxvm.symlinks
-      when: "{{ symlinks }}"
-    - role: beetbox-php-nginx
-      when: "{{ installed_extras_nginx }}"
+      tags: extras
     - role: alexdesignworks.dcr
       when: "{{ installed_extras_dcr }}"
+      tags: extras
+    - role: beetboxvm.symlinks
+      when: "{{ symlinks }}"
+      tags: extras
+    - role: beetboxvm.drupal
+      when: "'{{ beet_project }}' == 'drupal'"
+      tags: project
+    - role: beetboxvm.backdrop
+      when: "'{{ beet_project }}' == 'backdrop'"
+      tags: project
+    - role: beetboxvm.cakephp
+      when: "'{{ beet_project }}' == 'cakephp'"
+      tags: project
+    - role: beetboxvm.concrete5
+      when: "'{{ beet_project }}' == 'concrete5'"
+      tags: project
+    - role: beetboxvm.kohana
+      when: "'{{ beet_project }}' == 'kohana'"
+      tags: project
+    - role: beetboxvm.modx
+      when: "'{{ beet_project }}' == 'modx'"
+      tags: project
+    - role: beetboxvm.silverstripe
+      when: "'{{ beet_project }}' == 'silverstripe'"
+      tags: project
+    - role: beetboxvm.slim
+      when: "'{{ beet_project }}' == 'slim'"
+      tags: project
+    - role: beetboxvm.symfony
+      when: "'{{ beet_project }}' == 'symfony'"
+      tags: project
+    - role: beetboxvm.wordpress
+      when: "'{{ beet_project }}' == 'wordpress'"
+      tags: project
+    - role: beetboxvm.packages
+      when: "{{ extra_packages }}"
+      tags: beetbox
+    - role: beetbox-web
+      when: "{{ installed_extras_web }}"
+      tags: beetbox
+    - role: beetbox-apparmor
+      when: "{{ installed_extras_apparmor }}"
+      tags: beetbox
+    - role: beetbox-php-nginx
+      when: "{{ installed_extras_nginx }}"
+      tags: beetbox
 
   tasks:
 
@@ -156,6 +219,9 @@
     - include: "{{ item }}"
       with_fileglob:
         - "{{ beet_custom_post_tasks }}"
+      tags:
+        - post
+        - custom
 
     - name: Create welcome message.
       template:

--- a/provisioning/beetbox.sh
+++ b/provisioning/beetbox.sh
@@ -2,6 +2,7 @@
 
 # Set default environment variables.
 BEET_PLAYBOOK=${1:-provision}
+BEET_TAGS=${2:-all}
 BEET_HOME=${BEET_HOME:-"/beetbox"}
 BEET_BASE=${BEET_BASE:-"/var/beetbox"}
 BEET_USER=${BEET_USER:-"vagrant"}
@@ -71,7 +72,7 @@ beetbox_adhoc() {
 }
 
 beetbox_play() {
-  ansible-playbook $ANSIBLE_DEBUG $ANSIBLE_HOME/playbook-$1.yml
+  ansible-playbook $ANSIBLE_DEBUG $ANSIBLE_HOME/playbook-$1.yml --tags "${2:-all}"
 }
 
 # Initialise beetbox.
@@ -84,7 +85,7 @@ beetbox_play config
 beetbox_play update
 
 # Provision VM.
-beetbox_play $BEET_PLAYBOOK
+beetbox_play $BEET_PLAYBOOK $BEET_TAGS
 
 # Print welcome message.
 sudo touch $BEET_HOME/.beetbox/results-$BEET_PLAYBOOK.txt


### PR DESCRIPTION
This PR will allow you to specify which roles/tasks are run during provisioning.

We can extend this further and add more tags, perhaps even 1 per role so you can be very specific in what roles to run.

As an example you can run `BEET_TAGS=pre vagrant provision` to only run the pre tasks.
