### PR TITLE
Set bash PATH for Composer vendor binaries

### DIFF
--- a/provisioning/ansible/roles/beetbox-init/tasks/main.yml
+++ b/provisioning/ansible/roles/beetbox-init/tasks/main.yml
@@ -55,3 +55,30 @@
     line: "SSH_HOME={{ beet_ssh_home }} && [ -e $SSH_HOME ] && cd $SSH_HOME"
   become: no
   when: beet_ssh_home is defined
+
+- name: Set PATH for Composer vendor binaries.
+  lineinfile:
+    dest: "/home/{{ beet_user }}/.bashrc"
+    state: present
+    create: yes
+    regexp: "^\\s*export PATH=\"{{ path_item | regex_escape() }}:\\$PATH\""
+    line: |
+      # Add Composer vendor binaries to PATH.
+      if [ -d "{{ path_item }}" ]; then
+        export PATH="{{ path_item }}:$PATH";
+      fi
+    owner: "{{ beet_user }}"
+    group: "{{ beet_user }}"
+    mode: 0644
+  with_first_found:
+    - files:
+      - "vendor/bin"
+      paths:
+      - "{{ beet_base }}"
+      - "{{ beet_root }}"
+      - "{{ beet_web }}"
+      - "{{ composer_home_path }}"
+      skip: true
+  loop_control:
+    loop_var: path_item
+  when: "{{ installed_extras_composer }}"


### PR DESCRIPTION
When I have Composer installed dependencies in my project, I'd prefer to use their vendor binaries to any installed as part of beetbox. For example, when we have Drush as a Composer managed dependency, at a specific version in our project, I want to have that preferred over the version installed by beetbox.

The following Pull Request is a suggestion. I've been copying it as a post task to beetbox projects to save me getting everyone to add these lines to their beetbox `~/.bashrc`:

``` sh
# Add Beetbox project vendor binaries to PATH.
if [ -d "/var/beetbox/vendor/bin" ]; then
  export PATH="/var/beetbox/vendor/bin:$PATH";
fi
```
