### PR TITLE
Docs: Contributing forking

### DIFF
--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -2,9 +2,9 @@
 
 Contributing is easy, the hardest part is knowing which project to add your pull request to.
 
-The main knowledge required is [Ansible](https://www.ansible.com/): it's pretty easy to pick up and they have some good docs available &mdash; http://docs.ansible.com/.
+The main knowledge required is [Ansible](https://www.ansible.com/): it's pretty easy to pick up and there is very good [Ansible documentation](http://docs.ansible.com/) available.
 
-The main project Beetbox core (https://github.com/beetboxvm/beetbox) is essentially some plumbing to initiate a set of external roles hosted on [Ansible galaxy](https://galaxy.ansible.com).
+The [Beetbox project](https://github.com/beetboxvm/beetbox) is essentially some plumbing to initiate a set of external roles hosted on [Ansible galaxy](https://galaxy.ansible.com).
 
 We have a few internal ansible tasks, but these are only for low level setup and a few features like custom tasks and the welcome message you see at the end of provisioning.
 
@@ -29,7 +29,7 @@ From this point you can modify anything inside the [`provisioning`](https://gith
 
 # Forking the project
 
-Please follow these instructions to fork the project: https://help.github.com/articles/fork-a-repo/
+Please follow these instructions to [Fork a project on Github](https://help.github.com/articles/fork-a-repo/).
 
 Next, you'll want to change you local repo to use the fork
 ```
@@ -40,7 +40,7 @@ Now you should be able to branch and push changes to your fork of the project.
  
 # Creating a PR
 
-We use pull requests to accept changes to the project. There's already good docs for doing this on github: https://help.github.com/articles/using-pull-requests/
+We use pull requests to accept changes to the project. Please read this article about [using pull requests on Github](https://help.github.com/articles/using-pull-requests/).
 
 # Roles
 

--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -25,7 +25,7 @@ This has been modified to use a debug mode which will:
 
 From this point you can modify anything inside the [`provisioning`](https://github.com/beetboxvm/beetbox/tree/master/provisioning) directory and apply changes with `vagrant provision`.
 
-*Note: sometimes it's easier to disable (comment out) all roles when debugging, but be careful as there can be role dependencies.
+**Note:** sometimes it's easier to disable (comment out) all roles when debugging, but be careful as there can be role dependencies.
 
 # Forking the project
 

--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -6,7 +6,7 @@ The main knowledge required is [Ansible](https://www.ansible.com/): it's pretty 
 
 The [Beetbox project](https://github.com/beetboxvm/beetbox) is essentially some plumbing to initiate a set of external roles hosted on [Ansible galaxy](https://galaxy.ansible.com).
 
-We have a few internal ansible tasks, but these are only for low level setup and a few features like custom tasks and the welcome message you see at the end of provisioning.
+We have a few internal Ansible tasks, but these are only for low level setup and a few features like custom tasks and the welcome message you see at the end of provisioning.
 
 # Setup
 
@@ -21,7 +21,7 @@ This has been modified to use a debug mode which will:
 
 - show more details when provisioning
 - mount [`provisioning`](https://github.com/beetboxvm/beetbox/tree/master/provisioning) directory into the VM, so it's editable and changes could be picked up by `vagrant provision`
-- checkout the ansible roles from their source repo, rather than from ansible galaxy
+- checkout the Ansible roles from their source repo, rather than from Ansible galaxy
 
 From this point you can modify anything inside the [`provisioning`](https://github.com/beetboxvm/beetbox/tree/master/provisioning) directory and apply changes with `vagrant provision`.
 

--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -31,10 +31,14 @@ From this point you can modify anything inside the [`provisioning`](https://gith
 
 Please follow these instructions to [Fork a project on Github](https://help.github.com/articles/fork-a-repo/).
 
-Next, you'll want to change you local repo to use the fork
+Next, you'll want to change your local repository to point at your new remote fork and add an upstream remote to keep it up-to-date.
+```sh
+git remote set-url origin https://github.com/YOUR_USERNAME/beetbox.git
+git remote add upstream https://github.com/beetboxvm/beetbox.git
+git fetch --all
 ```
-git remote set-url origin [git URL of fork]
-```
+
+Please follow these instructions to [Sync a fork and keep it up-to-date](https://help.github.com/articles/syncing-a-fork/).
 
 Now you should be able to branch and push changes to your fork of the project.
  


### PR DESCRIPTION
## Proposed Changes

These changes prompted this pull request:

- Make URLs in the Contributing page work as hyperlinks
- Link to Github article sync a fork

These changes I made while I was there:

- Small fix to broken markdown (bold Notes)
- Capitalise usages of name Ansible 

