### PR TITLE
Remove Vagrantfile when beet/box package is uninstalled.

### DIFF
--- a/composer/src/Plugin.php
+++ b/composer/src/Plugin.php
@@ -55,8 +55,10 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
         $source = __DIR__ . '/../../.beetbox/Vagrantfile';
         $target =  $baseDir . '/Vagrantfile';
 
-        if (!file_exists($target) || md5_file($source) != md5_file($target)) {
-            copy($source, $target);
+        if (file_exists($source)) {
+            if (!file_exists($target) || md5_file($source) != md5_file($target)) {
+                copy($source, $target);
+            }
         }
     }
 


### PR DESCRIPTION
## Proposed Changes

- Change

Deletes the project Vagrantfile If the package is not installed.
