### PR TITLE
Docs: Cross platform install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ You can see some examples in [`config.yml`](https://github.com/beetboxvm/beetbox
 To get a simple Drupal 8 site up and running with Beetbox, run the following commands:
 
 ```
-drush dl drupal --drupal-project-rename=drupal8 && cd drupal8
-curl https://raw.githubusercontent.com/beetboxvm/beetbox/master/Vagrantfile > Vagrantfile
+drush pm-download drupal-8 --drupal-project-rename=drupal8 && cd drupal8
+php -r "readfile('https://raw.githubusercontent.com/beetboxvm/beetbox/master/Vagrantfile');" > Vagrantfile
 vagrant up
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ To get a simple Drupal 8 site up and running with Beetbox, run the following com
 
 ```
 drush dl drupal --drupal-project-rename=drupal8 && cd drupal8
-curl https://raw.githubusercontent.com/beetboxvm/beetbox/master/Vagrantfile > Vagrantfile
+php -r "readfile('https://raw.githubusercontent.com/beetboxvm/beetbox/master/Vagrantfile');" > Vagrantfile
 vagrant up
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ You can see some examples in [`config.yml`](https://github.com/beetboxvm/beetbox
 To get a simple Drupal 8 site up and running with Beetbox, run the following commands:
 
 ```
-drush pm-download drupal --drupal-project-rename=drupal8 && cd drupal8
+drush pm-download drupal-8 --drupal-project-rename=drupal8 && cd drupal8
 php -r "readfile('https://raw.githubusercontent.com/beetboxvm/beetbox/master/Vagrantfile');" > Vagrantfile
 vagrant up
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ You can see some examples in [`config.yml`](https://github.com/beetboxvm/beetbox
 To get a simple Drupal 8 site up and running with Beetbox, run the following commands:
 
 ```
-drush dl drupal --drupal-project-rename=drupal8 && cd drupal8
+drush pm-download drupal --drupal-project-rename=drupal8 && cd drupal8
 php -r "readfile('https://raw.githubusercontent.com/beetboxvm/beetbox/master/Vagrantfile');" > Vagrantfile
 vagrant up
 ```


### PR DESCRIPTION
## Proposed Changes

In the ongoing quest to modernise this documentation, I submit this change to probably the most important, most read, most used part: _The install commands_

- Make install commands work cross-platform without additional requirements
- Future proof Drush download commands

## Explanation

> Why remove `curl` and why not use `wget` instead?

Because neither `curl` nor `wget` are available on all platforms where Vagrant and Drush are used. CentOS does not have `wget` by default and `curl` is a developer library that also must be downloaded on most platforms.

> So why PHP, as it's not installed by default on all platforms?

We switch to PHP for download in line with both Composer and Drush installers. It is highly likely that our users will have PHP, particularly when a Drush command forms part of our install instructions.

## Relates To

- Issue #255 

## Notify

- @thom8  - you look like the last one to touch the Install commands.
