### PR TITLE
Make docker build use beetbox profile.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ vendor/
 
 # Prevent Ansible related files.
 
-.beetbox/installed
+installed
 provisioning/ansible/config/*
 !provisioning/ansible/config/beetbox.config.yml
 provisioning/packer/includes/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,19 +2,18 @@ FROM ubuntu:14.04
 
 WORKDIR /beetbox
 
-ENV BEET_PROFILE 'docker'
-
 EXPOSE 80
 
 VOLUME ["/var/beetbox"]
 
-# Install sudo.
-RUN apt-get update && \
-    apt-get install -y sudo && \
-    apt-get clean
-
 # Copy source files into the build context.
-COPY . /beetbox
+COPY ./provisioning /beetbox/provisioning
 
 # Provision Beetbox.
 RUN /beetbox/provisioning/beetbox.sh
+
+# Delete innodb log files.
+RUN rm /var/lib/mysql/ib_logfile*
+
+EXPOSE 22 80 443
+CMD ["/bin/bash", "/start.sh"]

--- a/provisioning/ansible/playbook-provision.yml
+++ b/provisioning/ansible/playbook-provision.yml
@@ -242,7 +242,7 @@
     - name: Create welcome message.
       template:
         src: "{{ welcome_template }}"
-        dest: "{{ beet_home }}/.beetbox/results-provision.txt"
+        dest: "{{ beet_home }}/results-provision.txt"
         force: yes
         mode: 0644
       become: no

--- a/provisioning/ansible/playbook-setup.yml
+++ b/provisioning/ansible/playbook-setup.yml
@@ -16,8 +16,9 @@
     - config/local.config.yml
 
   roles:
-    - { role: beetbox-circleci, when: "{{ circleci }}"}
-    - { role: beetbox-vagrant, when: "{{ lookup('env','VAGRANT_INIT') == 'true' }}"}
-    - { role: beetbox-ubuntu, when: "{{ lookup('env','UBUNTU_INIT') == 'true' }}"}
-    - { role: beetbox-virtualbox, when: "{{ lookup('env','VIRTUALBOX_INIT') == 'true' }}"}
-    - { role: beetbox-packer, when: "{{ lookup('env','INSTALL_PACKER') == 'true' }}"}
+    - { role: beetbox-circleci, when: "{{ circleci }}" }
+    - { role: beetbox-docker, when: ansible_virtualization_type == 'docker' }
+    - { role: beetbox-vagrant }
+    - { role: beetbox-ubuntu }
+    - { role: beetbox-virtualbox, when: "{{ lookup('env','VIRTUALBOX_INIT') == 'true' }}" }
+    - { role: beetbox-packer, when: "{{ lookup('env','INSTALL_PACKER') == 'true' }}" }

--- a/provisioning/ansible/roles/beetbox-apparmor/tasks/main.yml
+++ b/provisioning/ansible/roles/beetbox-apparmor/tasks/main.yml
@@ -1,12 +1,19 @@
 ---
+- name: Check if AppArmor service exists
+  stat:
+    path: /etc/init.d/apparmor
+  register: apparmor_service_status
+
 - name: Ensure MySQL AppArmor profile is disabled (for slow query log).
   file:
     path: /etc/apparmor.d/disable/usr.sbin.mysqld
     src: /etc/apparmor.d/usr.sbin.mysqld
     state: link
   register: mysql_apparmor
-  when: mysql_slow_query_log_enabled
+  when: mysql_slow_query_log_enabled and apparmor_service_status.stat.exists
 
 - name: Restart AppArmor if necessary.
-  service: name=apparmor state=restarted
+  service:
+    name: apparmor
+    state: restarted
   when: mysql_apparmor.changed

--- a/provisioning/ansible/roles/beetbox-docker/files/start.sh
+++ b/provisioning/ansible/roles/beetbox-docker/files/start.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Start supervisor
+supervisord -n -c /etc/supervisor/conf.d/supervisord.conf

--- a/provisioning/ansible/roles/beetbox-docker/files/supervisord.conf
+++ b/provisioning/ansible/roles/beetbox-docker/files/supervisord.conf
@@ -1,0 +1,16 @@
+[supervisord]
+nodaemon=true
+logfile=/tmp/supervisord.log
+logfile_maxbytes=50MB
+logfile_backups=10
+loglevel=info
+pidfile=/tmp/supervisord.pid
+
+[program:sshd]
+command=/usr/sbin/sshd -D
+
+[program:mysqld]
+command=/usr/bin/mysqld_safe --skip-syslog
+
+[program:apache2]
+command=/usr/sbin/apache2ctl -D FOREGROUND

--- a/provisioning/ansible/roles/beetbox-docker/tasks/main.yml
+++ b/provisioning/ansible/roles/beetbox-docker/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+- name: Ensure apt cache is updated.
+  apt: update_cache=yes cache_valid_time=3600
+
+- name: Install docker packages
+  apt: "name={{ item }} state=installed"
+  with_items:
+    - mysql-server
+    - openssh-server
+    - supervisor
+    - python-pycurl
+    - build-essential
+
+- name: Ensure directories exists.
+  file:
+    path: "{{ item }}"
+    state: directory
+    mode: 0644
+  with_items:
+    - /var/log/supervisor
+    - /var/run/sshd
+
+- name: Add supervisor configuration.
+  copy:
+    src: supervisord.conf
+    dest: /etc/supervisor/conf.d/supervisord.conf
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Add docker startup script.
+  copy:
+    src: start.sh
+    dest: /start.sh
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Start MySQL service.
+  command: "service mysql start"

--- a/provisioning/ansible/roles/beetbox-ubuntu/tasks/main.yml
+++ b/provisioning/ansible/roles/beetbox-ubuntu/tasks/main.yml
@@ -2,15 +2,6 @@
 - name: Ensure apt cache is updated.
   apt: update_cache=yes cache_valid_time=3600
 
-- name: Get current kernel version.
-  shell: uname -r
-  register: current_kernel
-
-- name: Ensure correct kernel headers are installed.
-  apt:
-    name: "linux-headers-{{ current_kernel.stdout }}"
-    state: installed
-
 - name: Disable release upgrade prompt.
   lineinfile:
     dest: /etc/update-manager/release-upgrades
@@ -47,7 +38,3 @@
   with_items:
     - { regexp: '^UseDNS', line: 'UseDNS no' }
     - { regexp: '^GSSAPIAuthentication', line: 'GSSAPIAuthentication no' }
-
-- name: Disable the ufw firewall (since we use a simple iptables firewall).
-  command: >
-    ufw disable

--- a/provisioning/ansible/roles/beetbox-virtualbox/tasks/main.yml
+++ b/provisioning/ansible/roles/beetbox-virtualbox/tasks/main.yml
@@ -1,4 +1,13 @@
 ---
+- name: Get current kernel version.
+  shell: uname -r
+  register: current_kernel
+
+- name: Ensure correct kernel headers are installed.
+  apt:
+    name: "linux-headers-{{ current_kernel.stdout }}"
+    state: installed
+
 # VirtualBox tools installation.
 - name: Check if VirtualBox is running the guest VM.
   stat: path=/home/vagrant/.vbox_version

--- a/provisioning/beetbox.sh
+++ b/provisioning/beetbox.sh
@@ -41,10 +41,11 @@ beetbox_setup() {
 
   # Install ansible.
   if [ ! -d "/etc/ansible" ]; then
-    sudo apt-get -qq -y install software-properties-common > /dev/null 2>&1
-    sudo apt-add-repository -y ppa:ansible/ansible > /dev/null 2>&1
-    sudo apt-get -qq update > /dev/null 2>&1
-    sudo apt-get -qq -y install ansible > /dev/null 2>&1
+    sudo apt-get -qq update
+    sudo apt-get -y install software-properties-common
+    sudo apt-add-repository -y ppa:ansible/ansible
+    sudo apt-get -qq update
+    sudo apt-get -y install ansible
   fi
 
   # Clone beetbox if BEET_HOME doesn't exist.
@@ -64,7 +65,7 @@ beetbox_setup() {
   beetbox_play setup
 
   # Create $BEET_HOME/.beetbox_installed
-  beetbox_adhoc file "path=$BEET_HOME/.beetbox/installed state=touch"
+  beetbox_adhoc file "path=$BEET_HOME/installed state=touch"
 }
 
 beetbox_adhoc() {
@@ -76,7 +77,7 @@ beetbox_play() {
 }
 
 # Initialise beetbox.
-[ ! -f "$BEET_HOME/.beetbox/installed" ] && beetbox_setup
+[ ! -f "$BEET_HOME/installed" ] && beetbox_setup
 
 # Create default config files.
 beetbox_play config
@@ -88,5 +89,5 @@ beetbox_play update
 beetbox_play $BEET_PLAYBOOK $BEET_TAGS
 
 # Print welcome message.
-sudo touch $BEET_HOME/.beetbox/results-$BEET_PLAYBOOK.txt
-sudo cat $BEET_HOME/.beetbox/results-$BEET_PLAYBOOK.txt
+sudo touch $BEET_HOME/results-$BEET_PLAYBOOK.txt
+sudo cat $BEET_HOME/results-$BEET_PLAYBOOK.txt


### PR DESCRIPTION
## Proposed Changes

- Change

This will build the `beet/box` container as close to the vagrant box as possible, we can also look to update CI to use this build instead of provisioning the Circle CI main container.

From here we could create a fork to build from centos7 and work on removing/splitting out any ubuntu/debian dependencies.

## Relates To

- Issue #354

## Notify

@christopher-hopper 
@alexdesignworks 
