### PR TITLE
Find beet_root if index.php is not in project root.

### DIFF
--- a/provisioning/ansible/playbook-provision.yml
+++ b/provisioning/ansible/playbook-provision.yml
@@ -16,6 +16,38 @@
 
   pre_tasks:
 
+    - name: Check if index.php exists in beet_root.
+      stat:
+        path: "{{ beet_root }}/index.php"
+      register: root_index_found
+
+    - name: Get list of sub directories.
+      find:
+        paths: "{{ beet_base }}"
+        file_type: directory
+      register: sub_directories
+      when:
+        - "'{{ beet_root }}' == '{{ beet_base }}'"
+        - not root_index_found.stat.exists
+
+    - name: Look for index.php in project sub directories.
+      stat:
+        path: "{{ item.path }}/index.php"
+      with_items: "{{ sub_directories.files }}"
+      register: possible_root_paths
+      when:
+        - "'{{ beet_root }}' == '{{ beet_base }}'"
+        - not root_index_found.stat.exists
+
+    - name: Override beet_root if index.php found.
+      set_fact:
+        beet_root: "{{ item.item.path }}"
+      with_items: "{{ possible_root_paths.results }}"
+      when:
+        - "'{{ beet_root }}' == '{{ beet_base }}'"
+        - item.stat.exists
+        - not root_index_found.stat.exists
+
     - name: Check pre tasks directory exists.
       stat:
         path: "{{ beet_custom_pre_tasks }}"


### PR DESCRIPTION
## Proposed Changes

- Change

When an `index.php` file is not found in the root of the project this role will search through the 1st level subdirectories to attempt to find an `index.php` file. If found it will set `beet_root` to this directory.

This will only run if you haven't overridden the default `beet_root`.
In the case where you have multiple subdirectories with an `index.php` and no `index.php` in the root the last one found will be used, however you still have the option to override `beet_root` to set the default path as above.
If you need multiple virtual hosts you can still define them by overriding `apache_vhosts`.

## Relates To

- Issue #375

## Notify

- @christopher-hopper 
