### PR TITLE
Move config up one level to support setting config with CLI

### DIFF
--- a/.beetbox/Vagrantfile
+++ b/.beetbox/Vagrantfile
@@ -16,7 +16,7 @@ composer_json = "#{beet_root}/composer.json"
 # Default vagrant config.
 vconfig = {
   'vagrant_box' => 'beet/box',
-  'vagrant_box_version' => '~> 0.4.0',
+  'vagrant_box_version' => '~> 0.5.0',
   'vagrant_ip' => '0.0.0.0',
   'vagrant_memory' => 1024,
   'vagrant_cpus' => 1,

--- a/.beetbox/Vagrantfile
+++ b/.beetbox/Vagrantfile
@@ -38,7 +38,7 @@ FileUtils.mkdir_p config_dir
 # Create config.yml from composer config.
 if File.exist?(composer_json)
   composer_conf = JSON.parse(File.read(composer_json))
-  cconfig = composer_conf['extra']['beetbox']['config'] rescue nil
+  cconfig = composer_conf['extra']['beetbox'] rescue nil
   File.open(project_config, "w") { |f| f.write(cconfig.to_yaml) } if cconfig.is_a?(Hash)
 end
 

--- a/circle.yml
+++ b/circle.yml
@@ -29,7 +29,7 @@ deployment:
         -token=$ATLAS_TOKEN
         -name="beet/dev"
         -var "beet_version=master"
-        -var "box_version=0.4.$CIRCLE_BUILD_NUM"
+        -var "box_version=0.5.$CIRCLE_BUILD_NUM"
         /beetbox/provisioning/beet-dev.json
   release:
     tag: /[0-9]+\.[0-9]+\.[0-9]+/


### PR DESCRIPTION
## Proposed Changes

- Change

Currently composer looks in `extra.beetbox.config` and generates config.

This PR moves it back to `extra.beetbox` which will allow modifying config via composer CLI as it has only allow max depth of 3 levels.

https://getcomposer.org/doc/03-cli.md#modifying-extra-values